### PR TITLE
qsettings error message

### DIFF
--- a/programs/us/us.cpp
+++ b/programs/us/us.cpp
@@ -124,6 +124,24 @@ US_Win::US_Win( QWidget* parent, Qt::WindowFlags flags )
     qDebug( "US_Win: invalid global memory" );
   }
   
+  if ( !US_Settings::status().isEmpty() ) {
+     qDebug( "US_Win: invalid settings" );
+     QMessageBox::critical(this
+                           ,windowTitle()
+                           ,QString(
+                                    tr(
+                                       "There is a error with your settings file:\n"
+                                       "\"%1\"\n"
+                                       "This can cause various problems and should be corrected.\n"
+                                       )
+                                    )
+                           .arg( US_Settings::status() )
+                           ,QMessageBox::Ok
+                           ,QMessageBox::NoButton
+                           ,QMessageBox::NoButton
+                           );
+  }
+
   g.set_global_position( QPoint( 50, 50 ) ); // Ensure initialization
   QPoint p = g.global_position();
   setGeometry( QRect( p, p + QPoint( 710, 532 ) ) );

--- a/utils/us_settings.cpp
+++ b/utils/us_settings.cpp
@@ -511,3 +511,28 @@ bool US_Settings::get_DA_status( const QString& da_type )
       
 }
 /*****************************************************************/
+
+QString US_Settings::status()
+{
+  QSettings settings( US3, "UltraScan" );
+  settings.setValue( "status_test", true );
+  settings.sync();
+  settings.remove( "status_test" );
+  
+  switch ( settings.status() ) {
+  case QSettings::NoError :
+     return "";
+     break;
+  case QSettings::AccessError :
+     return QString( "Access error. Check permissions and ownership of %1" ).arg( settings.fileName() );
+     break;
+  case QSettings::FormatError :
+     return QString( "Settings format error. The file %1 is garbled" ).arg( settings.fileName() );
+     break;
+  default:
+     return QString( "Unknown settings error %1. Perhaps remove the file %1 and try again." ).arg( settings.status() ).arg( settings.fileName() );
+     break;
+  }
+}
+     
+     

--- a/utils/us_settings.cpp
+++ b/utils/us_settings.cpp
@@ -530,7 +530,7 @@ QString US_Settings::status()
      return QString( "Settings format error. The file %1 is garbled" ).arg( settings.fileName() );
      break;
   default:
-     return QString( "Unknown settings error %1. Perhaps remove the file %1 and try again." ).arg( settings.status() ).arg( settings.fileName() );
+     return QString( "Unknown settings error %1. Perhaps remove the file %2 and try again." ).arg( settings.status() ).arg( settings.fileName() );
      break;
   }
 }

--- a/utils/us_settings.h
+++ b/utils/us_settings.h
@@ -160,5 +160,9 @@ class US_UTIL_EXTERN US_Settings
     // DA status
     static void set_DA_status( const QString& );
     static bool get_DA_status( const QString& );
+
+    //! \brief get the status of QSettings
+    //! \return empty QString if ok. otherwise an error message QString
+    static QString status();
 };
 #endif


### PR DESCRIPTION
# QSettings failed silently 

## Background
Amy could change investigator but it would not "keep". Debugging revealed that her QSettings UltraScan.conf file had the wrong ownership.

## This update
 - inform the user with a messagebox at startup of ```us``` about this issue
 - added a static ```QString US_Settings::status()``` called in ```us.cpp``` to check status and display the message
![qsettings](https://user-images.githubusercontent.com/11505970/118309396-d2475280-b4b2-11eb-8347-6ceec30de452.png)
 - could be added in other entry points of UltraScan (us_com_project?)
