### PR TITLE
fix for clients behind firewalls that replace ssl certs

### DIFF
--- a/utils/us_http_post.cpp
+++ b/utils/us_http_post.cpp
@@ -10,6 +10,10 @@ US_HttpPost::US_HttpPost( const QString& url, const QString& request ) : QObject
                       QString( "application/x-www-form-urlencoded" ) );
   httpPost.setUrl( QUrl( url ) );
 
+  QSslConfiguration conf = httpPost.sslConfiguration();
+  conf.setPeerVerifyMode(QSslSocket::VerifyNone);
+  httpPost.setSslConfiguration(conf);
+  
   reply = manager->post( httpPost, request.toLatin1().data() );
     
   connect( reply, SIGNAL( finished    ( void ) ), 


### PR DESCRIPTION
### Background

Firewalls can be configured to replace certificates of remote endpoints.
This causes registration to fail.

### The fix
Setting the QNetWorkRequest's QSslConfiguration peerVerifyMode to QSslSocket::VerifyNone bypasses this error.
According to:
https://doc.qt.io/qt-5/qsslsocket.html#PeerVerifyMode-enum
```
QSslSocket will not request a certificate from the peer. 
You can set this mode if you are not interested in the identity of the 
other side of the connection. The connection will still be encrypted, 
and your socket will still send its local certificate to the peer if it's requested.
```
Note that the modified class US_HttpPost only appears to be used  by us_license.cpp
```
[ehb@mlspauc02 ultrascan3test]$ find . -type f | xargs grep US_HttpPost | grep -v moc/moc
Binary file ./lib/libus_gui.so.10.0.0 matches
Binary file ./lib/libus_utils.so.10.0.0 matches
Binary file ./gui/obj/us_license.o matches
./gui/us_license.cpp:  US_HttpPost* transmit = new US_HttpPost( url, req );
./gui/us_license.cpp:  US_HttpPost* transmit = new US_HttpPost( url, request );
./mainpage.dox:    - \ref US_HttpPost
Binary file ./utils/obj/moc_us_http_post.o matches
Binary file ./utils/obj/us_http_post.o matches
./utils/us_http_post.h:class US_UTIL_EXTERN US_HttpPost : public QObject
./utils/us_http_post.h:    US_HttpPost( const QString&, const QString& );
./utils/us_http_post.cpp:US_HttpPost::US_HttpPost( const QString& url, const QString& request ) : QObject()
./utils/us_http_post.cpp:void US_HttpPost::postFinished( void )
./utils/us_http_post.cpp:void US_HttpPost::postError( QNetworkReply::NetworkError error )
[ehb@mlspauc02 ultrascan3test]$	
```
### Testing
Tested successful registration on a server with this issue.
