### PR TITLE
Unable to edit curve properties in US_Integral

### DIFF
--- a/programs/us_integral/us_integral.cpp
+++ b/programs/us_integral/us_integral.cpp
@@ -668,7 +668,8 @@ DbgLv(1) << "LD:   efname" << efname;
    US_DataIO::loadData( edir, efname, edata );
 DbgLv(1) << "LD:  edata: desc run cell chan"
  << edata.description << edata.runID << edata.cell << edata.channel;
-   tsys.label    = edata.description;
+   tsys.label    = edata.description + " (" + efname.section(".",0,0) + " "
+           + efname.section(".",-5,-2) + " " + tsys.method + ")" + "[" + QString::number( alldis.size() ) + "]";
 
    // Now, get associated solution,buffer values
    QString soluID;


### PR DESCRIPTION
Fix for [Combine integral distributions - MW config problem #9](https://github.com/ehb54/ultrascan-tickets/issues/9)

Extended the label of the curves by wavelength, analysis method, cell, sector and a counter to avoid curves with the same name