### PR TITLE
Fix vhw plots do not overwrite old vhw files on the database | US Ticket 4

### DIFF
--- a/programs/us_vhw_enhanced/us_vhw_enhanced.cpp
+++ b/programs/us_vhw_enhanced/us_vhw_enhanced.cpp
@@ -711,15 +711,24 @@ DbgLv(1) << "(T)PLOT ENV save: plot3File" << plot3File;
       copy_data_files( plot3File, plot4File, data2File );
    }
 
-   // Copy csv files from results to reports directory
-   if QFile( drpt0File ).exists())
-        QFile( drpt0File ).remove();
+   // Copy csv files from results to reports directory, remove old report files
+   if (QFile( drpt0File ).exists())
+   {
+       QFile( drpt0File ).remove();
+DbgLv(1) << drpt0File << " deleted.";
+   };
    QFile( data0File ).copy( drpt0File );
-   if QFile( drpt1File ).exists())
-    QFile( drpt1File ).remove();
+   if (QFile( drpt1File ).exists())
+   {
+       QFile( drpt1File) .remove();
+DbgLv(1) << drpt1File << " deleted";
+    };
    QFile( data1File ).copy( drpt1File );
-   if QFile( drpt2File ).exists())
-    QFile( drpt2File ).remove();
+   if (QFile( drpt2File ).exists())
+   {
+       QFile( drpt2File ).remove();
+DbgLv(1) << drpt2File << " deleted";
+    };
    QFile( data2File ).copy( drpt2File );
    // Build results,reports output files lists
    files << " ";

--- a/programs/us_vhw_enhanced/us_vhw_enhanced.cpp
+++ b/programs/us_vhw_enhanced/us_vhw_enhanced.cpp
@@ -712,8 +712,14 @@ DbgLv(1) << "(T)PLOT ENV save: plot3File" << plot3File;
    }
 
    // Copy csv files from results to reports directory
+   if QFile( drpt0File ).exists())
+        QFile( drpt0File ).remove();
    QFile( data0File ).copy( drpt0File );
+   if QFile( drpt1File ).exists())
+    QFile( drpt1File ).remove();
    QFile( data1File ).copy( drpt1File );
+   if QFile( drpt2File ).exists())
+    QFile( drpt2File ).remove();
    QFile( data2File ).copy( drpt2File );
    // Build results,reports output files lists
    files << " ";


### PR DESCRIPTION
Fix for [vhw plots do not overwrite old vhw files on the database](https://github.com/ehb54/ultrascan-tickets/issues/4)