### PR TITLE
Chore: Enable QT_ENABLE_HIGHDPI_SCALING for proper scaled main window

### DIFF
--- a/programs/us/us.cpp
+++ b/programs/us/us.cpp
@@ -53,6 +53,7 @@ int main( int argc, char* argv[] )
 
   application.initialize();
 #else
+  qputenv("QT_ENABLE_HIGHDPI_SCALING",QByteArray("1"));
   QApplication application( argc, argv );
   application.setApplicationDisplayName( "UltraScan III" );
 #endif


### PR DESCRIPTION
Fixing previous reported scaling and window size issues on high dpi monitors by enabling qts highdpi scaling