### PR TITLE
fix for windows help

### DIFF
--- a/programs/us_helpdaemon/us_helpdaemon.cpp
+++ b/programs/us_helpdaemon/us_helpdaemon.cpp
@@ -10,11 +10,14 @@
 
 US_HelpDaemon::US_HelpDaemon( const QString& page, QObject* o ) : QObject( o )
 {
-#ifdef Q_OS_WIN
-  QString location = US_Settings::appBaseDir() + "/bin/manual.qch";
-#else
+
+  // special Q_OS_WIN code apparently does not work anymore 
+  // #ifdef Q_OS_WIN
+  // QString location = US_Settings::appBaseDir() + "/bin/manual.qch";
+  // #else
   QString location = US_Settings::appBaseDir() + "/bin/manual.qhc";
-#endif
+  // #endif
+
   QString url      = "qthelp://ultrascaniii/";
   if ( !page.contains( "manual/" ) )
      url.append( "manual/" );


### PR DESCRIPTION
In my tests, in windows packages, the help/assistant didn't work. it came up with an empty help window. Apparently, something has changed (perhaps building with msys2/mingw64?) & now us_helpdaemon can use the same manual.qhc file uses on other OSs.
 