### PR TITLE
Creation of Buffer components

### DIFF
--- a/gui/us_buffer_gui.cpp
+++ b/gui/us_buffer_gui.cpp
@@ -842,7 +842,7 @@ US_BufferGuiNew::US_BufferGuiNew( int *invID, int *select_db_disk,
    pb_spectrum              = us_pushbutton( tr( "Enter Spectrum" ) );
    //QPushButton* pb_spectrum = us_pushbutton( tr( "Enter Spectrum" ) );
    QPushButton* pb_help     = us_pushbutton( tr( "Help" ) );
-
+   QPushButton *pb_new_bcomp = us_pushbutton("Create new");
    QGridLayout* lo_manual   = us_checkbox(
          tr( "Manual unadjusted Density and Viscosity" ), ck_manual );
 
@@ -898,7 +898,14 @@ US_BufferGuiNew::US_BufferGuiNew( int *invID, int *select_db_disk,
    main->addWidget( pb_spectrum,     row,   4, 1, 2 );
    main->addWidget( pb_help,         row++, 6, 1, 2 );
    main->addWidget( le_concen,       row++, 4, 1, 4 );
-   main->addWidget( bn_allcomps,     row,   0, 1, 4 );
+   if (US_Settings::us_inv_level()>1){
+         main->addWidget(bn_allcomps, row, 0, 1, 3);
+         main->addWidget(pb_new_bcomp,row, 3,1,1);
+         connect(pb_new_bcomp, SIGNAL(clicked()), this, SLOT(create_new_buffer_component()));
+   }
+   else{
+         main->addWidget(bn_allcomps, row, 0, 1, 4);
+   }
    main->addWidget( bn_bufcomps,     row++, 4, 1, 4 );
    main->addWidget( lw_allcomps,     row,   0, 5, 4 );
    main->addWidget( lw_bufcomps,     row,   4, 5, 4 );
@@ -1098,6 +1105,71 @@ DbgLv(1) << "BufN:SL: adco:   concen" << concen << "newitem" << entext;
                        !le_viscos ->text().isEmpty() );
    pb_accept->setEnabled( can_accept );
    pb_spectrum->setEnabled( can_accept );
+}
+
+
+void US_BufferGuiNew::create_new_buffer_component() {
+   DbgLv(1) << "BufN:New BComp";
+   // check if connected to database
+   if (!from_db) { // if not, exceed
+      QMessageBox::critical(this, tr("No database connection"), tr("Without a database you can create new buffer components."));
+      return;
+   }
+   // check user level against database
+   US_Passwd   pw;
+   US_DB2      db( pw.getPasswd() );
+
+   if ( db.lastErrno() != US_DB2::OK )
+   {
+//qDebug() << "USCFG: UpdInv: ERROR connect";
+      QMessageBox::information( this,
+                                tr( "Error" ),
+                                tr( "Error making the DB connection.\n" ) );
+
+      return;
+   }
+
+   QStringList q( "get_user_info" );
+   db.query( q );
+   db.next();
+
+   int ID        = db.value( 0 ).toInt();
+   QString fname = db.value( 1 ).toString();
+   QString lname = db.value( 2 ).toString();
+   int     level = db.value( 5 ).toInt();
+   if (level < 2){
+      QMessageBox::critical(this, tr("Insufficient permissions"),
+                            tr("You have not enough permissions on the currently selected database to create "
+                               "new buffer components.\nYou need to be an admin or superuser."));
+      return;
+   }
+   // permissions sufficient
+   // create empty buffer component
+   US_BufferComponent bc;
+   US_BufferComponentRequerster* bcomp_dialog = new US_BufferComponentRequerster(&bc,component_list);
+   bcomp_dialog -> exec();
+   qApp->processEvents();
+   if (!bc.name.isEmpty())return;
+   bc.saveToDB(&db);
+
+   // update component list
+   lw_allcomps->clear();
+   // update buffer components file
+   //  $ULTRASCAN3/etc/bufferComponents xml file:
+   component_list.clear();
+   US_BufferComponent::getAllFromDB(pw.getPasswd(), component_list);
+   US_BufferComponent::putAllToHD(component_list);
+   QStringList keys = component_list.keys();
+   std::sort(keys.begin(),keys.end());
+
+   for (int ii = 0; ii < keys.size(); ii++) {
+      QString key = keys[ii];
+      US_BufferComponent bcomp = component_list[key];
+
+      // Insert the buffer component with its key
+      QString sitem = bcomp.name + " (" + bcomp.range + ")";
+      new QListWidgetItem(sitem, lw_allcomps, key.toInt());
+   }
 }
 
 // Slot for select of buffer component
@@ -1847,3 +1919,199 @@ void US_BufferGui::bufferRejected( void )
    reject();
 }
 
+US_BufferComponentRequerster::US_BufferComponentRequerster(US_BufferComponent* comp_, QMap<QString,US_BufferComponent>& list_) : US_WidgetsDialog(nullptr, nullptr),
+                                                                                   comp(comp_), component_list(list_) {
+   setWindowTitle(tr("Buffer component creator"));
+   setPalette(US_GuiSettings::frameColor());
+
+   main = new QGridLayout(this);
+   main->setSpacing(2);
+   main->setContentsMargins(2, 2, 2, 2);
+   // construct the base buffer description
+
+   QString description_text =
+         tr("To create a new buffer component, please enter a name, the unit for the range values.\n") +
+         tr("Additionally you have to enter the density and viscosity coefficients for this component.\n")+
+         tr("Click on the check box if the buffer component is gradient forming.\n\n") +
+         tr("Click the \"Finish\" button to load the entered values.\n") +
+         tr("Click the \"Cancel\" button to exit this dialog.");
+   lb_description = us_banner(description_text);
+   lb_description->setAlignment(Qt::AlignVCenter | Qt::AlignLeft);
+   lb_name = us_label(tr("Name of the buffer component"));
+   lb_unit = us_label(tr("Unit for concentration"));
+   lb_range = us_label(tr("Range for the buffer component"));
+   lb_range2 = us_label(tr("-"));
+   lb_visc = us_banner("Viscosity Coefficients");
+   lb_dens = us_banner("Density Coefficients");
+   le_name = us_lineedit("");
+   le_lrange = us_lineedit("");
+   le_urange = us_lineedit("");
+   le_unit = us_lineedit("");
+   le_density1 = us_lineedit("");
+   le_density2 = us_lineedit("");
+   le_density3 = us_lineedit("");
+   le_density4 = us_lineedit("");
+   le_density5 = us_lineedit("");
+   le_viscosity1 = us_lineedit("");
+   le_viscosity2 = us_lineedit("");
+   le_viscosity3 = us_lineedit("");
+   le_viscosity4 = us_lineedit("");
+   le_viscosity5 = us_lineedit("");
+   QLabel* lb_range3 = us_label(tr("in M"));
+   lb_density0 = us_label(tr("Density coefficient independent of c"));
+   lb_density1 = us_label(tr("Density coefficient for sqrt(c) *1E3"));
+   lb_density2 = us_label(tr("Density coefficient for c *1E2"));
+   lb_density3 = us_label(tr("Density coefficient for c<sup>2</sup> *1E3"));
+   lb_density4 = us_label(tr("Density coefficient for c<sup>3</sup> *1E4"));
+   lb_density5 = us_label(tr("Density coefficient for c<sup>4</sup> *1E6"));
+   lb_viscosity0 = us_label(tr("Viscosity coefficient independent of c"));
+   lb_viscosity1 = us_label(tr("Viscosity coefficient for sqrt(c) *1E3"));
+   lb_viscosity2 = us_label(tr("Viscosity coefficient for c *1E2"));
+   lb_viscosity3 = us_label(tr("Viscosity coefficient for c<sup>2</sup> *1E3"));
+   lb_viscosity4 = us_label(tr("Viscosity coefficient for c<sup>3</sup> *1E4"));
+   lb_viscosity5 = us_label(tr("Viscosity coefficient for c<sup>4</sup> *1E6"));
+   QGridLayout* gfbox   = us_checkbox( tr( "Gradient-Forming" ), ck_gf );
+   int row = 0;
+   main->addWidget(lb_description, row++, 0, 1, 7);
+   main->addWidget(lb_name, row, 0, 1, 3);
+   main->addWidget(le_name, row++, 3, 1, 4);
+   main->addWidget(lb_unit, row, 0,1,3);
+   main->addWidget(le_unit,row++,4,1,1);
+   main->addWidget(lb_range, row, 0, 1, 2);
+   main->addWidget(le_lrange, row, 2, 1, 1);
+   main->addWidget(lb_range2, row, 3,1,1);
+   main->addWidget(le_urange, row, 4,1,1);
+   main->addWidget(lb_range3, row, 5,1,2);
+   main->addWidget(lb_unit, row, 5,1,1);
+   main->addWidget(le_unit,row++,6,1,1);
+   main->addWidget(lb_dens, row++, 0, 1, 7);
+   main->addWidget(lb_density0, row, 0, 1, 5);
+   main->addWidget(le_density0, row++, 5, 1, 2);
+   main->addWidget(lb_density1, row, 0, 1, 5);
+   main->addWidget(le_density1, row++, 5, 1, 2);
+   main->addWidget(lb_density2, row, 0, 1, 5);
+   main->addWidget(le_density2, row++, 5, 1, 2);
+   main->addWidget(lb_density3, row, 0, 1, 5);
+   main->addWidget(le_density3, row++, 5, 1, 2);
+   main->addWidget(lb_density4, row, 0, 1, 5);
+   main->addWidget(le_density4, row++, 5, 1, 2);
+   main->addWidget(lb_density5, row, 0, 1, 5);
+   main->addWidget(le_density5, row++, 5, 1, 2);
+   main->addWidget(lb_visc, row++, 0, 1, 7);
+   main->addWidget(lb_viscosity0, row, 0, 1, 5);
+   main->addWidget(le_viscosity0, row++, 5, 1, 2);
+   main->addWidget(lb_viscosity1, row, 0, 1, 5);
+   main->addWidget(le_viscosity1, row++, 5, 1, 2);
+   main->addWidget(lb_viscosity2, row, 0, 1, 5);
+   main->addWidget(le_viscosity2, row++, 5, 1, 2);
+   main->addWidget(lb_viscosity3, row, 0, 1, 5);
+   main->addWidget(le_viscosity3, row++, 5, 1, 2);
+   main->addWidget(lb_viscosity4, row, 0, 1, 5);
+   main->addWidget(le_viscosity4, row++, 5, 1, 2);
+   main->addWidget(lb_viscosity5, row, 0, 1, 5);
+   main->addWidget(le_viscosity5, row++, 5, 1, 2);
+   main->addLayout(gfbox,row++,0,1,7);
+
+
+   QPushButton *pb_cancel = us_pushbutton(tr("Cancel"));
+   pb_accept = us_pushbutton(tr("Accept"));
+   main->addWidget(pb_cancel, row, 0, 1, 2);
+   main->addWidget(pb_accept, row, 2, 1, 2);
+   pb_accept->setEnabled(false);
+   connect(pb_cancel, SIGNAL(clicked()), this, SLOT(cancelled()));
+   connect(pb_accept, SIGNAL(clicked()), this, SLOT(accept()));
+   connect(le_name, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_lrange, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_urange, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_unit, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(ck_gf, SIGNAL(toggled(bool)), this, SLOT  (gf_ck(bool)));
+   connect(le_density0, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_density1, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_density2, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_density3, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_density4, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_density5, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_viscosity0, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_viscosity1, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_viscosity2, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_viscosity3, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_viscosity4, SIGNAL(editingFinished()), this, SLOT(edit()));
+   connect(le_viscosity5, SIGNAL(editingFinished()), this, SLOT(edit()));
+}
+
+void US_BufferComponentRequerster::cancelled(void) {
+   comp->name = QString("");
+   this->close();
+}
+
+void US_BufferComponentRequerster::accept(void) {
+   comp->name = le_name->text();
+   comp->unit = le_unit->text();
+   comp->range = QString::number(le_lrange->text().toDouble(),'f',3)+'-'+QString::number(le_urange->text().toDouble(),'f',3)+' M';
+   comp->dens_coeff[0] = le_density0->text().toDouble();
+   comp->dens_coeff[1] = le_density1->text().toDouble()*1e-3;
+   comp->dens_coeff[2] = le_density2->text().toDouble()*1e-2;
+   comp->dens_coeff[3] = le_density3->text().toDouble()*1e-3;
+   comp->dens_coeff[4] = le_density4->text().toDouble()*1e-4;
+   comp->dens_coeff[5] = le_density5->text().toDouble()*1e-6;
+   comp->visc_coeff[0] = le_viscosity0->text().toDouble();
+   comp->visc_coeff[1] = le_viscosity1->text().toDouble()*1e-3;
+   comp->visc_coeff[2] = le_viscosity2->text().toDouble()*1e-2;
+   comp->visc_coeff[3] = le_viscosity3->text().toDouble()*1e-3;
+   comp->visc_coeff[4] = le_viscosity4->text().toDouble()*1e-4;
+   comp->visc_coeff[5] = le_viscosity5->text().toDouble()*1e-6;
+   comp->grad_form = ck_gf->isChecked();
+   // check if it exists already
+   QList<QString> problems;
+   bool exists_already = false;
+   if (!(comp->unit == QString("M") || comp->unit == QString("mM"))){
+      problems << QString(tr("Invalid unit, currently only mM and M are supported."));
+      le_unit->setText("");
+   }
+   if (le_lrange->text().toDouble() <= le_urange->text().toDouble()){
+      problems << QString(tr("Invalid range, the upper limit is smaller or equal the lower limit."));
+      le_urange->setText("");
+      le_lrange->setText("");
+   }
+   foreach(US_BufferComponent bc, component_list){
+      if (bc.name == comp->name && comp->range == bc.range){
+         exists_already = true;
+         problems << QString(tr("A buffer component with the same name and range already exists."));
+         break;
+      }
+   }
+   QString msg = QString("");
+   if (!problems.isEmpty()){
+      msg += QString("The following problems were discovered while checking the input:\n");
+            foreach(QString prob, problems){
+            msg += prob + "\n";
+         }
+   }
+   if (exists_already){
+      QMessageBox::critical(this, tr("Duplicate error"),
+                            tr("A buffer component with the same name and range already exists.\n\n")+msg);
+      return;
+   }
+   else {
+      QMessageBox::information(this, tr("Input error"),
+                            msg);
+      return;
+   }
+   this->close();
+}
+
+void US_BufferComponentRequerster::edit(void) {
+   if (le_name->text().isEmpty() || le_unit->text().isEmpty() || le_density0->text().isEmpty() || le_density1->text().isEmpty() ||
+       le_density2->text().isEmpty() || le_density3->text().isEmpty() || le_density4->text().isEmpty() ||
+       le_density5->text().isEmpty() || le_viscosity0->text().isEmpty() || le_viscosity1->text().isEmpty() ||
+       le_viscosity2->text().isEmpty() || le_viscosity3->text().isEmpty() || le_viscosity4->text().isEmpty() ||
+       le_viscosity5->text().isEmpty() || le_lrange->text().isEmpty() || le_urange->text().isEmpty()) {
+      pb_accept->setEnabled(false);
+      return;
+   }
+   pb_accept->setEnabled(true);
+}
+
+void US_BufferComponentRequerster::gf_ck(bool) {
+
+}

--- a/gui/us_buffer_gui.cpp
+++ b/gui/us_buffer_gui.cpp
@@ -1947,11 +1947,13 @@ US_BufferComponentRequerster::US_BufferComponentRequerster(US_BufferComponent* c
    le_lrange = us_lineedit("");
    le_urange = us_lineedit("");
    le_unit = us_lineedit("");
+   le_density0 = us_lineedit("");
    le_density1 = us_lineedit("");
    le_density2 = us_lineedit("");
    le_density3 = us_lineedit("");
    le_density4 = us_lineedit("");
    le_density5 = us_lineedit("");
+   le_viscosity0 = us_lineedit("");
    le_viscosity1 = us_lineedit("");
    le_viscosity2 = us_lineedit("");
    le_viscosity3 = us_lineedit("");

--- a/gui/us_buffer_gui.cpp
+++ b/gui/us_buffer_gui.cpp
@@ -2051,17 +2051,17 @@ void US_BufferComponentRequerster::accept(void) {
    comp->unit = le_unit->text();
    comp->range = QString::number(le_lrange->text().toDouble(),'f',3)+'-'+QString::number(le_urange->text().toDouble(),'f',3)+' M';
    comp->dens_coeff[0] = le_density0->text().toDouble();
-   comp->dens_coeff[1] = le_density1->text().toDouble()*1e-3;
-   comp->dens_coeff[2] = le_density2->text().toDouble()*1e-2;
-   comp->dens_coeff[3] = le_density3->text().toDouble()*1e-3;
-   comp->dens_coeff[4] = le_density4->text().toDouble()*1e-4;
-   comp->dens_coeff[5] = le_density5->text().toDouble()*1e-6;
+   comp->dens_coeff[1] = le_density1->text().toDouble();
+   comp->dens_coeff[2] = le_density2->text().toDouble();
+   comp->dens_coeff[3] = le_density3->text().toDouble();
+   comp->dens_coeff[4] = le_density4->text().toDouble();
+   comp->dens_coeff[5] = le_density5->text().toDouble();
    comp->visc_coeff[0] = le_viscosity0->text().toDouble();
-   comp->visc_coeff[1] = le_viscosity1->text().toDouble()*1e-3;
-   comp->visc_coeff[2] = le_viscosity2->text().toDouble()*1e-2;
-   comp->visc_coeff[3] = le_viscosity3->text().toDouble()*1e-3;
-   comp->visc_coeff[4] = le_viscosity4->text().toDouble()*1e-4;
-   comp->visc_coeff[5] = le_viscosity5->text().toDouble()*1e-6;
+   comp->visc_coeff[1] = le_viscosity1->text().toDouble();
+   comp->visc_coeff[2] = le_viscosity2->text().toDouble();
+   comp->visc_coeff[3] = le_viscosity3->text().toDouble();
+   comp->visc_coeff[4] = le_viscosity4->text().toDouble();
+   comp->visc_coeff[5] = le_viscosity5->text().toDouble();
    comp->grad_form = ck_gf->isChecked();
    // check if it exists already
    QList<QString> problems;

--- a/gui/us_buffer_gui.h
+++ b/gui/us_buffer_gui.h
@@ -182,6 +182,7 @@ class US_BufferGuiNew : public US_Widgets
 
       void new_description ();
       void add_component   ();
+      void create_new_buffer_component();
       void select_bcomp    ();
       void remove_bcomp    ( QListWidgetItem* );
       void recalc_density  ( void );
@@ -381,6 +382,66 @@ class US_GUI_EXTERN US_BufferGui : public US_WidgetsDialog
       void editBufAccepted  ( void );
       void editBufCanceled  ( void );
 
+};
+
+
+class US_GUI_EXTERN US_BufferComponentRequerster : public US_WidgetsDialog {
+   Q_OBJECT
+
+   public:
+      US_BufferComponentRequerster(US_BufferComponent* comp_, QMap<QString, US_BufferComponent>&);
+
+   private:
+      QGridLayout* main;
+      US_BufferComponent* comp;
+      QMap<QString, US_BufferComponent> component_list;
+      QLabel *lb_description;
+      QLabel *lb_dens;
+      QLabel *lb_visc;
+      QLabel *lb_viscosity0;
+      QLabel *lb_density0;
+      QLineEdit *le_density0;
+      QLineEdit *le_viscosity0;
+      QLabel *lb_density1;
+      QLabel *lb_viscosity1;
+      QLineEdit *le_density1;
+      QLineEdit *le_viscosity1;
+      QLabel *lb_density2;
+      QLabel *lb_viscosity2;
+      QLineEdit *le_density2;
+      QLineEdit *le_viscosity2;
+      QLabel *lb_density3;
+      QLabel *lb_viscosity3;
+      QLineEdit *le_density3;
+      QLineEdit *le_viscosity3;
+      QLabel *lb_density4;
+      QLabel *lb_viscosity4;
+      QLineEdit *le_density4;
+      QLineEdit *le_viscosity4;
+      QLabel *lb_density5;
+      QLabel *lb_viscosity5;
+      QLineEdit *le_density5;
+      QLineEdit *le_viscosity5;
+      QLabel *lb_unit;
+      QLabel *lb_range;
+      QLabel *lb_range2;
+      QLabel *lb_name;
+      QLineEdit *le_name;
+      QLineEdit *le_lrange;
+      QLineEdit *le_urange;
+      QLineEdit *le_unit;
+      QGridLayout* gfbox;
+      QPushButton *pb_accept;
+      QCheckBox*    ck_gf;
+
+   private slots:
+      void cancelled(void);
+
+      void accept(void);
+
+      void edit(void);
+
+      void gf_ck(bool);
 };
 #endif
 

--- a/utils/us_buffer.cpp
+++ b/utils/us_buffer.cpp
@@ -210,6 +210,36 @@ void US_BufferComponent::putAllToHD(
    file.close();
 }
 
+int US_BufferComponent::saveToDB(US_DB2 * db) {
+   QStringList q;
+   // construct density and viscosity
+   QString density;
+   for (int i = 0; i < 6; i++) {
+      density += QString(i > 0 ? "" : " ") + QString::number(dens_coeff[i], 'f', 5);
+   }
+   QString viscosity;
+   for (int i = 0; i < 6; i++) {
+      viscosity += QString(i > 0 ? "" : " ") + QString::number(visc_coeff[i], 'f', 5);
+   }
+
+   q.clear();
+   q << "create_buffer_component" << name << unit << range
+     << US_Util::bool_string(grad_form) << density << viscosity;
+
+   db->statusQuery(q);
+
+   if (db->lastErrno() != US_DB2::OK) {
+      qDebug() << "create_buffer_component error=" << db->lastErrno();
+      return -1;
+   }
+
+   int idBufferComponent = db->lastInsertID();
+   //qDebug() << "new_buffer-idBuffer" << idBuffer;
+
+   qDebug() << "buffer_component_ID for new buffer component: " << idBufferComponent;
+   componentID = QString::number(idBufferComponent);
+}
+
 //-------------  US_Buffer
 US_Buffer::US_Buffer()
 {

--- a/utils/us_buffer.h
+++ b/utils/us_buffer.h
@@ -35,6 +35,11 @@ class US_UTIL_EXTERN US_BufferComponent
       //! Get the info for an individual component from the DB.
       //! \param db A \ref US_DB2 structure to an opened connection to the DB.
       void getInfoFromDB( US_DB2* = 0 );
+   
+      //! \brief Write a new buffer to the DB.
+      //! \param db An open database connection
+      //! \return The buffercomponentID of the new buffer component
+      int saveToDB( US_DB2* = 0);
 
    private:
       static void component( QXmlStreamReader&, QMap< QString, US_BufferComponent >& );


### PR DESCRIPTION
Together with [this pull request](https://github.com/ehb54/us3_sql/pull/7) I implemented the more dynamic approach for buffer components for superuser or admin. The GUI change is minimal, the button for creating one appears in the new buffer gui incase the user level is bigger 1 which should be superuser and admin if I remember correct. For normal users nothing changes. If the button is pressed I double check the user level to handle any manipulation of the stored user level (not very likely, but just in case).
The user is prompted with a new dialog to enter all the details of the new component. I check for other components with the same name and concentration range to prevent duplicates.
The new buffer component is stored in the databse and then the program updates the local version and the list.

I tested it except the database related part, because of I have no db with enough permissions. 
I will create the patch file for the database if needed. Also in case you want a screenshot of the gui, let me know. @demeler 