### PR TITLE
Update make_all.pro

### DIFF
--- a/make_all.pro
+++ b/make_all.pro
@@ -20,6 +20,10 @@ gui.makefile = Makefile
 
 ## define all standalone programs as sub dir target dynamically by looking for *.pro files
 PROGRAMS = $$files(programs/*.pro,true)
+
+## remove us_mpi_analysis when building gui
+PROGRAMS -= "programs/us_mpi_analysis/us_mpi_analysis.pro"
+
 for(tmp, PROGRAMS){
 pro_file_name = $$basename(tmp)
 pro_name = $$section(pro_file_name,.pro,0,0 )


### PR DESCRIPTION
Fix to remove us_mpi_analysis when running `qmake && make` to build the gui
Related issue https://github.com/ehb54/ultrascan-tickets/issues/280