### PR TITLE
Update us_saxs_util_dmd.cpp

### DIFF
--- a/us_somo/develop/src/us_saxs_util_dmd.cpp
+++ b/us_somo/develop/src/us_saxs_util_dmd.cpp
@@ -3,11 +3,13 @@
 //Added by qt3to4:
 #include <QTextStream>
 
-#if defined( Q_OS_MACOS )
-# include "../include/bits_stdc++.h"
-#else
-# include <bits/stdc++.h>
-#endif
+// causes issues with MSYS2 gcc 12.2 compiles
+// not sure why we ever included these
+// #if defined( Q_OS_MACOS )
+// # include "../include/bits_stdc++.h"
+// #else
+// # include <bits/stdc++.h>
+// #endif
 
 
 #if !defined( Q_OS_WIN )

--- a/us_somo/develop/src/us_saxs_util_dmd.cpp
+++ b/us_somo/develop/src/us_saxs_util_dmd.cpp
@@ -3,14 +3,8 @@
 //Added by qt3to4:
 #include <QTextStream>
 
-// causes issues with MSYS2 gcc 12.2 compiles
-// not sure why we ever included these
-// #if defined( Q_OS_MACOS )
-// # include "../include/bits_stdc++.h"
-// #else
-// # include <bits/stdc++.h>
-// #endif
-
+#include <signal.h> // for kill()
+#include <array>    // for std::array
 
 #if !defined( Q_OS_WIN )
 # include <sys/wait.h>


### PR DESCRIPTION
Commented out bits header inclusion
Causes issues with g++ 12.2 on msys2
Still compiles fine without, don't recall why they were ever included.