### PR TITLE
remove std::as_const

### DIFF
--- a/programs/us_config/us_database.cpp
+++ b/programs/us_config/us_database.cpp
@@ -232,7 +232,7 @@ void US_Database::select_db( QListWidgetItem* entry )
   QString email     = dblist.at( 0 ).at( 6 );
   if ( email.isEmpty() )
   {
-    for (const auto & jj : std::as_const(dblist))
+    for (const auto & jj : dblist)
     {
       if ( ! jj.at( 6 ).isEmpty() )
       {
@@ -487,7 +487,7 @@ void US_Database::update_lw( const QString& current )
   }
   //qDebug() << "USCFG: UpdLw:  defaultDBname" << defaultDBname;
 
-  for (const auto & i : std::as_const(dblist))
+  for (const auto & i : dblist)
   {
     const QString& desc    = i.at( 0 );
     QString display = desc;
@@ -576,7 +576,7 @@ void US_Database::help( )
 
 void US_Database::save_default( )
 {
-  for (const auto & i : std::as_const(dblist))
+  for (const auto & i : dblist)
   {
     const QString& desc = i.at( 0 );
     DbgLv( 1 ) << "USCFG: svDef: desc" << desc;


### PR DESCRIPTION
This pull request includes several changes to the `programs/us_config/us_database.cpp` file. The main focus of these changes is to simplify the code by removing the use of `std::as_const` in various methods.

Code simplification:

* [`void US_Database::select_db( QListWidgetItem* entry )`](diffhunk://#diff-228129c1df914a242a852bd2f3bf890cd7f09ede201c2c10bd40db67f956cf1bL235-R235): Removed the use of `std::as_const` in the for loop iterating over `dblist`.
* [`void US_Database::update_lw( const QString& current )`](diffhunk://#diff-228129c1df914a242a852bd2f3bf890cd7f09ede201c2c10bd40db67f956cf1bL490-R490): Removed the use of `std::as_const` in the for loop iterating over `dblist`.
* [`void US_Database::save_default( )`](diffhunk://#diff-228129c1df914a242a852bd2f3bf890cd7f09ede201c2c10bd40db67f956cf1bL579-R579): Removed the use of `std::as_const` in the for loop iterating over `dblist`.