### PR TITLE
[FIX]: Ensure the initialization of all UI elements to prevent crashes

### DIFF
--- a/programs/us_edit/us_edit.cpp
+++ b/programs/us_edit/us_edit.cpp
@@ -45,7 +45,15 @@
 // Alt. Constructor
 US_Edit::US_Edit( QString auto_mode ) : US_Widgets()
 {
-    
+   pb_removeAllbutLast = us_pushbutton( tr( "Remove All but Last" ), true );
+   pb_baseline_correct = us_pushbutton( tr( "Correct Baseline" ), false );
+   pb_bll_modify       = us_pushbutton( tr( "Modify Baseline Correction for Selected Triple" ), false );
+   lb_baseline_correct = us_banner( tr( "Linear Baseline Correction" ) );
+   lb_bll_slope        = us_label( tr( "Slope:" ), -1 );
+   le_bll_slope        = us_lineedit( "", 1, true );
+   lb_bll_intercept    = us_label( tr( "Y-intercept:" ), -1 );
+   le_bll_intercept    = us_lineedit( "", 1, true );
+   pb_pass             = us_pushbutton( tr( "Accept Changes for a Channel" ), false );
    check        = US_Images::getIcon( US_Images::CHECK );
    invert       = 1.0;
    all_edits    = false;
@@ -74,9 +82,9 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
   triples_all_optics.clear();
   channels_all.clear();
   isSet_ref_wvl.clear();
- 
+
 //usmode = false;
- 
+
    setWindowTitle( tr( "Edit UltraScan Data" ) );
    setPalette( US_GuiSettings::frameColor() );
 
@@ -94,8 +102,8 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
    runInfo->addWidget( le_info );
 
    //top->addLayout( runInfo );
-   top -> addWidget( upperWidget ); 
-   
+   top -> addWidget( upperWidget );
+
    QHBoxLayout* main = new QHBoxLayout();
 
    leftWidget         = new QWidget();
@@ -107,7 +115,7 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
    left        ->setContentsMargins( 0, 1, 0, 1 );
    rightLayout ->setSpacing        ( 0 );
    rightLayout ->setContentsMargins( 0, 1, 0, 1 );
-   
+
    //QVBoxLayout* left = new QVBoxLayout;
 
    // Start of Grid Layout
@@ -120,8 +128,8 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
       pb_investigator->setEnabled( false );
 
    int     id      = US_Settings::us_inv_ID();
-   QString number  = ( id > 0 ) ? 
-      QString::number( US_Settings::us_inv_ID() ) + ": " 
+   QString number  = ( id > 0 ) ?
+      QString::number( US_Settings::us_inv_ID() ) + ": "
       : "";
    le_investigator = us_lineedit( number + US_Settings::us_inv_name(),
                                   1, true );
@@ -135,7 +143,7 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
    pb_details      = us_pushbutton( tr( "Run Details" ), false );
       pb_report    = us_pushbutton( tr( "View Report" ), false );
 
-   // Triple controls 
+   // Triple controls
    QLabel* lb_cell = us_banner( tr( "Channel Controls" ) );
 
    // Triple and Speed Step
@@ -228,7 +236,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    // Scan Controls
    QLabel* lb_scan = us_banner( tr( "Scan Controls" ) );
-   
+
    // Scans
    QLabel* lb_from = us_label(  tr( "Scan Focus from:" ), -1 );
    lb_from->setAlignment( Qt::AlignVCenter | Qt::AlignRight );
@@ -241,14 +249,14 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    ct_to          = us_counter( 3, 0.0, 0.0 ); // Update range upon load
    ct_to->setSingleStep( 1 );
-   
+
    // Exclude and Include pushbuttons
    pb_excludeRange = us_pushbutton( tr( "Exclude Scan Range" ), false );
    pb_exclusion    = us_pushbutton( tr( "Exclusion Profile" ),  false );
    pb_edit1       = us_pushbutton( tr( "Edit Single Scan" ), false );
    pb_include     = us_pushbutton( tr( "Include All" ), false );
 
-   // Edit controls 
+   // Edit controls
    QLabel* lb_edit = us_banner( tr( "Edit Controls" ) );
 
    // Edit Triple:Speed display (Equilibrium only)
@@ -284,23 +292,23 @@ pb_plateau->setVisible(false);
    le_baseline    = us_lineedit( "", 1, true );
 
 //*NEW STUFF
-//QLabel* 
+//QLabel*
    lb_dataStart   = us_label(      tr( "Data Start:" ), -1 );
-//QLineEdit* 
+//QLineEdit*
    le_dataStart   = us_lineedit( "", 1, true );
-//QPushButton* 
+//QPushButton*
    //pb_dataEnd     = us_pushbutton( tr( "Specify Range/End:" ), false );
    pb_dataEnd     = us_pushbutton( tr( "Specify Top/Bottom:" ), false );
 
    lb_dataEnd     = us_label(      tr( "Data End:" ), -1 );
-//QLineEdit* 
+//QLineEdit*
    le_dataEnd     = us_lineedit( "", 1, true );
-//QLabel* 
+//QLabel*
    lb_plateau     = us_label(      tr( "Plateau:" ), -1 );
-//QPushButton* 
+//QPushButton*
    pb_nextChan    = us_pushbutton( tr( "Next Triple" ), false );
    pb_priorChan   = us_pushbutton( tr( "Previous Triple" ), false );
-   
+
 //*NEW STUFF
    // OD Limit
    lb_odlim       = us_label( tr( "OD Limit:" ), -1 );
@@ -329,11 +337,11 @@ pb_plateau->setVisible(false);
    //pb_write       = us_pushbutton( tr( "Save Current Edit Profile" ), false );
    pb_write       = us_pushbutton( tr( "Save Edit Profiles" ), false );
    pb_emanual     = us_pushbutton( tr( "Edit Currently Selected Profile Manually" ), false );
-   
+
    lo_writemwl    = us_checkbox  ( tr( "Save to all Wavelengths" ),
                                    ck_writemwl, true );
 
-   // [ABDE]Base Line controls 
+   // [ABDE]Base Line controls
    lb_baseline_correct = us_banner( tr( "Linear Baseline Correction" ) );
    pb_bll_modify       = us_pushbutton( tr( "Modify Baseline Correction for Selected Triple" ), false );
    lb_bll_slope        = us_label(      tr( "Slope:" ), -1 );
@@ -346,14 +354,14 @@ pb_plateau->setVisible(false);
    lb_bll_intercept    -> setVisible( false );
    le_bll_slope        -> setVisible( false );
    le_bll_intercept    -> setVisible( false );
-         
+
    connect( pb_excludeRange, SIGNAL( clicked() ), SLOT( exclude_range() ) );
    connect( pb_details,      SIGNAL( clicked() ), SLOT( details()       ) );
    connect( pb_report,       SIGNAL( clicked() ), SLOT( view_report()   ) );
    connect( pb_investigator, SIGNAL( clicked() ),
                              SLOT  ( sel_investigator()         ) );
    connect( pb_load,         SIGNAL( clicked() ), SLOT( load()  ) );
-   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ),
                              SLOT  ( new_triple_auto         ( int ) ) );
    connect( pb_exclusion,    SIGNAL( clicked() ), SLOT( exclusion()     ) );
    connect( pb_edit1,        SIGNAL( clicked() ), SLOT( edit_scan()     ) );
@@ -377,14 +385,14 @@ pb_plateau->setVisible(false);
 
    connect( pb_nextChan,     SIGNAL( clicked() ), SLOT( next_triple_auto()   ) );
    connect( pb_priorChan,    SIGNAL( clicked() ), SLOT( prior_triple_auto()  ) );
-   
+
    connect( pb_float,        SIGNAL( clicked() ), SLOT( floating()  ) );
    connect( pb_write,        SIGNAL( clicked() ), SLOT( write_auto()  ) );
    connect( pb_emanual,      SIGNAL( clicked() ), SLOT( manual_edit_auto()  ) );
    connect( pb_bll_modify,   SIGNAL( clicked() ), SLOT( correct_bll_for_triple_auto() ) );
 
    connect ( this, SIGNAL( process_next_optics () ), SLOT ( process_optics_auto () )  );
-   
+
    // Lay out specs widgets and layouts
    int s_row = 0;
    specs->addWidget( pb_investigator, s_row,   0, 1, 2 );
@@ -402,7 +410,7 @@ pb_plateau->setVisible(false);
 
    specs->addWidget( pb_priorChan,     s_row,   0, 1, 3 );    //<--- ALEXEY
    specs->addWidget( pb_nextChan,     s_row++, 3, 1, 3 );
-   
+
 //*NEW STUFF
    specs->addWidget( lb_rpms,         s_row,   0, 1, 3 );
    specs->addWidget( cb_rpms,         s_row++, 3, 1, 3 );
@@ -410,7 +418,7 @@ pb_plateau->setVisible(false);
    specs->addWidget( ct_gaps,         s_row++, 3, 1, 3 );
    specs->addWidget( le_lxrng,        s_row++, 0, 1, 6 );
    specs->addWidget( lb_mwlctl,       s_row++, 0, 1, 6 );
-   //specs->addLayout( lo_lrange,       s_row,   0, 1, 3 );   <-- ALEXEY 
+   //specs->addLayout( lo_lrange,       s_row,   0, 1, 3 );   <-- ALEXEY
    //specs->addLayout( lo_custom,       s_row++, 3, 1, 3 );
    specs->addWidget( lb_ldelta,       s_row,   0, 1, 2 );
    specs->addWidget( ct_ldelta,       s_row,   2, 1, 1 );
@@ -421,7 +429,7 @@ pb_plateau->setVisible(false);
    specs->addWidget( cb_lend,         s_row++, 5, 1, 1 );
    specs->addWidget( pb_custom,       s_row,   0, 1, 3 );
    specs->addWidget( pb_incall,       s_row++, 3, 1, 3 );
-   //specs->addLayout( lo_radius,       s_row,   0, 1, 3 );    <-- ALEXEY 
+   //specs->addLayout( lo_radius,       s_row,   0, 1, 3 );    <-- ALEXEY
    //specs->addLayout( lo_waveln,       s_row++, 3, 1, 3 );
    specs->addWidget( lb_lplot,        s_row,   0, 1, 2 );
    specs->addWidget( cb_lplot,        s_row,   2, 1, 1 );
@@ -445,11 +453,11 @@ pb_plateau->setVisible(false);
    // Meniscus
    specs->addWidget( lb_meniscus,     s_row,   0, 1, 3 );
    specs->addWidget( le_meniscus,     s_row++, 3, 1, 3 );
-   
+
    specs->addWidget( pb_meniscus,     s_row++, 3, 1, 3 );
 
    // ALEXEY: for auto Interference
-  
+
    specs->addWidget( lb_airGap,       s_row,   0, 1, 3 );
    specs->addWidget( le_airGap,       s_row++, 3, 1, 3 );
    specs->addWidget( pb_airGap,       s_row,   0, 1, 3 );
@@ -496,7 +504,7 @@ pb_plateau->setVisible(false);
    specs->addWidget( pb_undo,         s_row++, 0, 1, 6 );
    specs->addWidget( pb_emanual,      s_row++, 0, 1, 6 );
    specs->addWidget( pb_write,        s_row++, 0, 1, 6 );
-   
+
    //*NEW STUFF
 //   specs->addWidget( lb_odlim,        s_row,   0, 1, 3 );
 //   specs->addWidget( ct_odlim,        s_row++, 3, 1, 3 );
@@ -535,16 +543,16 @@ pb_plateau->setVisible(false);
    // Hide some buttons
    if ( auto_mode.toStdString() == "AUTO")
      {
-       
+
        pb_investigator->hide();
        le_investigator->hide();
-       pb_load        ->hide(); 
+       pb_load        ->hide();
        pb_details     ->hide();
        pb_report      ->hide();
        lb_gaps        ->hide();
        ct_gaps        ->hide();
 
-       
+
        lb_scan        ->hide();
        lb_from        ->hide();
        lb_to          ->hide();
@@ -558,15 +566,15 @@ pb_plateau->setVisible(false);
        pb_meniscus    ->hide();
        pb_dataRange   ->hide();
 
-       pb_airGap      ->hide();  
+       pb_airGap      ->hide();
 
        pb_noise       ->hide();
        pb_residuals   ->hide();
        pb_invert      ->hide();
        pb_priorEdits  ->hide();
        pb_float       ->hide();
-       
-       
+
+
        pb_reset       ->hide();
        pb_help        ->hide();
        pb_accept      ->hide();
@@ -589,21 +597,21 @@ pb_plateau->setVisible(false);
        //pb_rarrow      ->hide();
        //lo_writemwl    ->hide();
        ck_writemwl    ->hide();
-	 
+
        rb_lrange      ->hide();
        rb_custom      ->hide();
        rb_radius      ->hide();
        rb_waveln      ->hide();
 
      }
-   
+
 
    // Plot layout on right side of window
-   plot = new US_Plot( data_plot, 
+   plot = new US_Plot( data_plot,
          tr( "Absorbance Data" ),
          tr( "Radius (in cm)" ), tr( "Absorbance" ),
          true, "", "rainbow" );
-   
+
    data_plot->setMinimumSize( 600, 400 );
 
    data_plot->enableAxis( QwtPlot::xBottom, true );
@@ -628,31 +636,31 @@ pb_plateau->setVisible(false);
    stpal.setColor( QPalette::Text, Qt::white );
    stpal.setColor( QPalette::Base, Qt::blue  );
    le_status->setPalette( stpal );
-   
+
    statInfo->addWidget( lb_status );
    statInfo->addWidget( le_status );
    left->addLayout( statInfo );
 
-   
+
    // main->addLayout( left );
    // main->addLayout( plot );
    // main->setStretchFactor( left, 2 );
    // main->setStretchFactor( plot, 3 );
-   
+
    rightLayout  ->addLayout( plot );
    main         ->addWidget( leftWidget, 2 );
    main         ->addWidget( rightWidget, 3 );
-   
+
    top ->addLayout( main );
-   
+
    reset();
 
    setMinimumSize( 950, 450 );
    adjustSize();
- 
+
    // TESTING...
    QMap < QString, QString > details;
-   
+
    // // Data WITH existing Aprofile corresponding to existing protocol!!!
    // details[ "invID_passed" ] = QString("77");
    // details[ "filename" ]     = QString("JohnsonC_DNA-control_013020-run680");
@@ -676,7 +684,7 @@ pb_plateau->setVisible(false);
     // details[ "filename" ]     = QString("001-Amy-MWL-if-test-3-run794-IP");
     // details[ "protocolName" ] = QString("001-Amy-MWL-if-test-3");
     // //  /****************************************************************************************/
-   
+
 
    // details[ "invID_passed" ] = QString("40");
    // details[ "filename" ]     = QString("KulkarniJ_NP025-D2O-0-20-17K_091220-run1285");
@@ -686,11 +694,11 @@ pb_plateau->setVisible(false);
    // /* Yu: */
    // details[ "invID_passed" ] = QString("86");
    // details[ "filename" ]     = QString("Yu_ABC-ala-indivdual_111320-run869");
-   // details[ "protocolName" ] = QString("Yu_ABC-ala-indivdual_111320");  
+   // details[ "protocolName" ] = QString("Yu_ABC-ala-indivdual_111320");
 
    // details[ "invID_passed" ] = QString("2");
    // details[ "filename" ]     = ("test-021621-IF-RI-B-run953-IP");
-   // details[ "protocolName" ] = QString("test-021621-IF-RI-B");  
+   // details[ "protocolName" ] = QString("test-021621-IF-RI-B");
 
    // details[ "invID_passed" ] = QString("2");
    // //details[ "filename" ]     = ("test-021721-IF-RI-B-run955-IP");
@@ -763,7 +771,7 @@ pb_plateau->setVisible(false);
    // details[ "autoflowID" ]   = QString("1140");
    // details[ "runID" ]        = QString("2023");
    // details[ "OptimaName" ]   = QString("Optima 1");
-   // details[ "expType" ]      = QString("VELOCITY");  
+   // details[ "expType" ]      = QString("VELOCITY");
 
    // details[ "invID_passed" ] = QString("165");
    // details[ "filename" ]     = QString("ABDE-Test-052124-run1693");
@@ -771,8 +779,8 @@ pb_plateau->setVisible(false);
    // details[ "statusID" ]     = QString("341");
    // details[ "autoflowID" ]   = QString("1152");
    // details[ "runID" ]        = QString("1693");
-   // details[ "OptimaName" ]   = QString("Optima 2");  
-   // details[ "expType" ]      = QString("ABDE");  
+   // details[ "OptimaName" ]   = QString("Optima 2");
+   // details[ "expType" ]      = QString("ABDE");
 
    // details[ "invID_passed" ] = QString("165");
    // details[ "filename" ]     = QString("AAV_GMP_test_030325-run2366-dataDiskRun-1515");
@@ -780,20 +788,28 @@ pb_plateau->setVisible(false);
    // details[ "statusID" ]     = QString("588");
    // details[ "autoflowID" ]   = QString("1515");
    // details[ "runID" ]        = QString("");
-   // details[ "OptimaName" ]   = QString("");  
+   // details[ "OptimaName" ]   = QString("");
    // details[ "expType" ]      = QString("ABDE");
    // details[ "dataSource" ]   = QString("dataDiskAUC");
-   
+
    //load_auto( details );
-  
+
 }
 
 
-// AUTO: Constructor for manual processing 
+// AUTO: Constructor for manual processing
 US_Edit::US_Edit( QVector< US_DataIO::RawData > allData, QStringList  triples,
 		  QString  workingDir, int currenChtInd, int plotind, QString exptype ) : US_Widgets()
 {
- 
+   pb_removeAllbutLast = us_pushbutton( tr( "Remove All but Last" ), true );
+   pb_baseline_correct = us_pushbutton( tr( "Correct Baseline" ), false );
+   pb_bll_modify       = us_pushbutton( tr( "Modify Baseline Correction for Selected Triple" ), false );
+   lb_baseline_correct = us_banner( tr( "Linear Baseline Correction" ) );
+   lb_bll_slope        = us_label( tr( "Slope:" ), -1 );
+   le_bll_slope        = us_lineedit( "", 1, true );
+   lb_bll_intercept    = us_label( tr( "Y-intercept:" ), -1 );
+   le_bll_intercept    = us_lineedit( "", 1, true );
+   pb_pass             = us_pushbutton( tr( "Accept Changes for a Channel" ), false );
    check        = US_Images::getIcon( US_Images::CHECK );
    invert       = 1.0;
    all_edits    = false;
@@ -815,9 +831,9 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
    us_edit_auto_mode_manual_bll = false;
    all_loaded = false;
    is_spike_auto = false;
- 
+
 //usmode = false;
- 
+
    setWindowTitle( tr( "Edit UltraScan Data Manually" ) );
    setPalette( US_GuiSettings::frameColor() );
 
@@ -848,8 +864,8 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
       pb_investigator->setEnabled( false );
 
    int     id      = US_Settings::us_inv_ID();
-   QString number  = ( id > 0 ) ? 
-      QString::number( US_Settings::us_inv_ID() ) + ": " 
+   QString number  = ( id > 0 ) ?
+      QString::number( US_Settings::us_inv_ID() ) + ": "
       : "";
    le_investigator = us_lineedit( number + US_Settings::us_inv_name(),
                                   1, true );
@@ -953,7 +969,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    // Scan Controls
    QLabel* lb_scan = us_banner( tr( "Scan Controls" ) );
-   
+
    // Scans
    QLabel* lb_from = us_label(  tr( "Scan Focus from:" ), -1 );
    lb_from->setAlignment( Qt::AlignVCenter | Qt::AlignRight );
@@ -966,7 +982,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    ct_to          = us_counter( 3, 0.0, 0.0 ); // Update range upon load
    ct_to->setSingleStep( 1 );
-   
+
    // Exclude and Include pushbuttons
    pb_excludeRange = us_pushbutton( tr( "Exclude Scan Range" ), false );
    pb_exclusion    = us_pushbutton( tr( "Exclusion Profile" ),  false );
@@ -976,7 +992,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
 
 
-   // Edit controls 
+   // Edit controls
    QLabel* lb_edit = us_banner( tr( "Edit Controls" ) );
 
    // Edit Triple:Speed display (Equilibrium only)
@@ -998,7 +1014,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
    lb_airGap->setHidden( true );
    le_airGap->setHidden( true );
 
-   
+
    // // Air Gap (hidden by default)
    // pb_airGap = us_pushbutton( tr( "Specify Air Gap" ), false );
    // le_airGap = us_lineedit( "", 1, true );
@@ -1019,18 +1035,18 @@ pb_plateau->setVisible(false);
    le_baseline    = us_lineedit( "", 1, true );
 
 //*NEW STUFF
-//QLabel* 
+//QLabel*
    lb_dataStart   = us_label(      tr( "Data Start:" ), -1 );
-//QLineEdit* 
+//QLineEdit*
    le_dataStart   = us_lineedit( "", 1, true );
-//QPushButton* 
+//QPushButton*
    //pb_dataEnd     = us_pushbutton( tr( "Specify Range/End:" ), false );
    pb_dataEnd     = us_pushbutton( tr( "Specify Top/Bottom:" ), false );
-//QLineEdit* 
+//QLineEdit*
    le_dataEnd     = us_lineedit( "", 1, false );
-//QLabel* 
+//QLabel*
    lb_plateau     = us_label(      tr( "Plateau:" ), -1 );
-//QPushButton* 
+//QPushButton*
    pb_nextChan    = us_pushbutton( tr( "Next Triple" ), false );
 //*NEW STUFF
    // OD Limit
@@ -1061,7 +1077,7 @@ pb_plateau->setVisible(false);
                                    ck_writemwl, true );
 
 
-   // Base Line controls 
+   // Base Line controls
    QLabel* lb_baseline_correct = us_banner( tr( "Linear Baseline Correction" ) );
    pb_baseline_correct         = us_pushbutton( tr( "Correct Baseline" ), false );
    QLabel* lb_bll_slope        = us_label(      tr( "Slope:" ), -1 );
@@ -1069,7 +1085,7 @@ pb_plateau->setVisible(false);
    QLabel* lb_bll_intercept    = us_label(      tr( "Y-intercept:" ), -1 );
    le_bll_intercept            = us_lineedit( "", 0, true );
    connect( pb_baseline_correct, SIGNAL( clicked() ), SLOT( set_linear_baseline_corr()  ) );
-   
+
 
    connect( pb_excludeRange, SIGNAL( clicked() ), SLOT( exclude_range() ) );
    connect( pb_details,      SIGNAL( clicked() ), SLOT( details()       ) );
@@ -1077,12 +1093,12 @@ pb_plateau->setVisible(false);
    connect( pb_investigator, SIGNAL( clicked() ),
                              SLOT  ( sel_investigator()         ) );
    connect( pb_load,         SIGNAL( clicked() ), SLOT( load()  ) );
-   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ),
                              SLOT  ( new_triple         ( int ) ) );
    connect( pb_exclusion,    SIGNAL( clicked() ), SLOT( exclusion()     ) );
    connect( pb_edit1,        SIGNAL( clicked() ), SLOT( edit_scan()     ) );
    connect( pb_removeAllbutLast,        SIGNAL( clicked() ), SLOT( exclude_all_but_last()     ) );
-   
+
    connect( pb_include,      SIGNAL( clicked() ), SLOT( include()       ) );
    connect( pb_meniscus,     SIGNAL( clicked() ), SLOT( set_meniscus()  ) );
    connect( pb_airGap,       SIGNAL( clicked() ), SLOT( set_airGap()    ) );
@@ -1150,7 +1166,7 @@ pb_plateau->setVisible(false);
    specs->addWidget( pb_exclusion,    s_row++, 3, 1, 3 );
    specs->addWidget( pb_edit1,        s_row,   0, 1, 3 );
    specs->addWidget( pb_removeAllbutLast, s_row,   0, 1, 3 );
-   
+
    specs->addWidget( pb_include,      s_row++, 3, 1, 3 );
    specs->addWidget( lb_edit,         s_row++, 0, 1, 6 );
    specs->addWidget( lb_edtrsp,       s_row,   0, 1, 3 );
@@ -1220,11 +1236,11 @@ pb_plateau->setVisible(false);
 
    QPushButton* pb_cancel  = us_pushbutton( tr( "Cancel" ) );
    pb_pass    = us_pushbutton( tr( "Accept Changes for a Channel" ), false );
-   
+
    connect( pb_cancel, SIGNAL( clicked() ), SLOT( close_manual_edit()  ) );
    connect( pb_pass,   SIGNAL( clicked()    ),
 	    this,      SLOT  ( pass_values() ) );
-   
+
    buttons->addWidget( pb_cancel );
    buttons->addWidget( pb_pass );
 
@@ -1235,7 +1251,7 @@ pb_plateau->setVisible(false);
    cb_triple      -> setEnabled( false );
    pb_investigator->hide();
    le_investigator->hide();
-   pb_load        ->hide(); 
+   pb_load        ->hide();
    pb_details     ->hide();
    pb_report      ->hide();
    lb_gaps        ->hide();
@@ -1244,7 +1260,7 @@ pb_plateau->setVisible(false);
 
    lb_baseline ->hide();
    le_baseline ->hide();
-   
+
    if ( exptype != "ABDE" )
      {
        lb_scan        ->hide();
@@ -1267,7 +1283,7 @@ pb_plateau->setVisible(false);
 
    // pb_meniscus    ->hide();
    // pb_dataRange   ->hide();
-   // pb_airGap      ->hide();  
+   // pb_airGap      ->hide();
 
    pb_noise       ->hide();
    pb_residuals   ->hide();
@@ -1278,20 +1294,20 @@ pb_plateau->setVisible(false);
    pb_spikes      ->hide();
    pb_undo        ->hide();
    pb_write       ->hide();
-   
+
    // pb_reset       ->hide();
    // pb_help        ->hide();
    // pb_accept      ->hide();
-   
+
    //---------------------
-      
+
 
    // Plot layout on right side of window
-   plot = new US_Plot( data_plot, 
+   plot = new US_Plot( data_plot,
          tr( "Absorbance Data" ),
          tr( "Radius (in cm)" ), tr( "Absorbance" ),
          true, "", "rainbow" );
-   
+
    data_plot->setMinimumSize( 600, 400 );
 
    data_plot->enableAxis( QwtPlot::xBottom, true );
@@ -1314,7 +1330,7 @@ pb_plateau->setVisible(false);
    top ->addLayout( main );
 
    qDebug() << "US_Edit manual setup 1";
-   
+
    reset();
 
    qDebug() << "US_Edit manual setup 2";
@@ -1327,7 +1343,7 @@ pb_plateau->setVisible(false);
    qDebug() << "US_Edit manual setup 3";
    load_manual_auto();
    qDebug() << "US_Edit manual setup 4";
-   
+
    //pre-select channel passed from main window:
    cb_triple->setCurrentIndex( currenChtInd );
    qDebug() << "US_Edit manual setup 5";
@@ -1351,7 +1367,15 @@ US_Edit::US_Edit( QVector< US_DataIO::RawData > allData, QStringList  triples,
 		  QString  workingDir, int currenChtInd, int plotind, QString exptype,
 		  QStringList editParams, QList<int> editParams_includes ) : US_Widgets()
 {
- 
+   pb_removeAllbutLast = us_pushbutton( tr( "Remove All but Last" ), true );
+   pb_baseline_correct = us_pushbutton( tr( "Correct Baseline" ), false );
+   pb_bll_modify       = us_pushbutton( tr( "Modify Baseline Correction for Selected Triple" ), false );
+   lb_baseline_correct = us_banner( tr( "Linear Baseline Correction" ) );
+   lb_bll_slope        = us_label( tr( "Slope:" ), -1 );
+   le_bll_slope        = us_lineedit( "", 1, true );
+   lb_bll_intercept    = us_label( tr( "Y-intercept:" ), -1 );
+   le_bll_intercept    = us_lineedit( "", 1, true );
+   pb_pass             = us_pushbutton( tr( "Accept Changes for a Channel" ), false );
    check        = US_Images::getIcon( US_Images::CHECK );
    invert       = 1.0;
    all_edits    = false;
@@ -1373,9 +1397,9 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
    us_edit_auto_mode_manual_bll = true;
    all_loaded = false;
    is_spike_auto = false;
- 
+
 //usmode = false;
- 
+
    setWindowTitle( tr( "Edit UltraScan Data Manually" ) );
    setPalette( US_GuiSettings::frameColor() );
 
@@ -1406,8 +1430,8 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
       pb_investigator->setEnabled( false );
 
    int     id      = US_Settings::us_inv_ID();
-   QString number  = ( id > 0 ) ? 
-      QString::number( US_Settings::us_inv_ID() ) + ": " 
+   QString number  = ( id > 0 ) ?
+      QString::number( US_Settings::us_inv_ID() ) + ": "
       : "";
    le_investigator = us_lineedit( number + US_Settings::us_inv_name(),
                                   1, true );
@@ -1511,7 +1535,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    // Scan Controls
    QLabel* lb_scan = us_banner( tr( "Scan Controls" ) );
-   
+
    // Scans
    QLabel* lb_from = us_label(  tr( "Scan Focus from:" ), -1 );
    lb_from->setAlignment( Qt::AlignVCenter | Qt::AlignRight );
@@ -1524,7 +1548,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    ct_to          = us_counter( 3, 0.0, 0.0 ); // Update range upon load
    ct_to->setSingleStep( 1 );
-   
+
    // Exclude and Include pushbuttons
    pb_excludeRange = us_pushbutton( tr( "Exclude Scan Range" ), false );
    pb_exclusion    = us_pushbutton( tr( "Exclusion Profile" ),  false );
@@ -1534,7 +1558,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
 
 
-   // Edit controls 
+   // Edit controls
    QLabel* lb_edit = us_banner( tr( "Edit Controls" ) );
 
    // Edit Triple:Speed display (Equilibrium only)
@@ -1556,7 +1580,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
    lb_airGap->setHidden( true );
    le_airGap->setHidden( true );
 
-   
+
    // // Air Gap (hidden by default)
    // pb_airGap = us_pushbutton( tr( "Specify Air Gap" ), false );
    // le_airGap = us_lineedit( "", 1, true );
@@ -1577,18 +1601,18 @@ pb_plateau->setVisible(false);
    le_baseline    = us_lineedit( "", 1, true );
 
 //*NEW STUFF
-//QLabel* 
+//QLabel*
    lb_dataStart   = us_label(      tr( "Data Start:" ), -1 );
-//QLineEdit* 
+//QLineEdit*
    le_dataStart   = us_lineedit( "", 1, true );
-//QPushButton* 
+//QPushButton*
    //pb_dataEnd     = us_pushbutton( tr( "Specify Range/End:" ), false );
    pb_dataEnd     = us_pushbutton( tr( "Specify Top/Bottom:" ), false );
-//QLineEdit* 
+//QLineEdit*
    le_dataEnd     = us_lineedit( "", 1, false );
-//QLabel* 
+//QLabel*
    lb_plateau     = us_label(      tr( "Plateau:" ), -1 );
-//QPushButton* 
+//QPushButton*
    pb_nextChan    = us_pushbutton( tr( "Next Triple" ), false );
 //*NEW STUFF
    // OD Limit
@@ -1619,7 +1643,7 @@ pb_plateau->setVisible(false);
                                    ck_writemwl, true );
 
 
-   // Base Line controls 
+   // Base Line controls
    QLabel* lb_baseline_correct = us_banner( tr( "Linear Baseline Correction" ) );
    pb_baseline_correct         = us_pushbutton( tr( "Correct Baseline" ), true );
    QLabel* lb_bll_slope        = us_label(      tr( "Slope:" ), -1 );
@@ -1627,7 +1651,7 @@ pb_plateau->setVisible(false);
    QLabel* lb_bll_intercept    = us_label(      tr( "Y-intercept:" ), -1 );
    le_bll_intercept            = us_lineedit( "", 0, true );
    connect( pb_baseline_correct, SIGNAL( clicked() ), SLOT( set_linear_baseline_corr()  ) );
-   
+
 
    connect( pb_excludeRange, SIGNAL( clicked() ), SLOT( exclude_range() ) );
    connect( pb_details,      SIGNAL( clicked() ), SLOT( details()       ) );
@@ -1635,12 +1659,12 @@ pb_plateau->setVisible(false);
    connect( pb_investigator, SIGNAL( clicked() ),
                              SLOT  ( sel_investigator()         ) );
    connect( pb_load,         SIGNAL( clicked() ), SLOT( load()  ) );
-   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ),
                              SLOT  ( new_triple         ( int ) ) );
    connect( pb_exclusion,    SIGNAL( clicked() ), SLOT( exclusion()     ) );
    connect( pb_edit1,        SIGNAL( clicked() ), SLOT( edit_scan()     ) );
    connect( pb_removeAllbutLast,        SIGNAL( clicked() ), SLOT( exclude_all_but_last()     ) );
-   
+
    connect( pb_include,      SIGNAL( clicked() ), SLOT( include()       ) );
    connect( pb_meniscus,     SIGNAL( clicked() ), SLOT( set_meniscus()  ) );
    connect( pb_airGap,       SIGNAL( clicked() ), SLOT( set_airGap()    ) );
@@ -1708,7 +1732,7 @@ pb_plateau->setVisible(false);
    specs->addWidget( pb_exclusion,    s_row++, 3, 1, 3 );
    specs->addWidget( pb_edit1,        s_row,   0, 1, 3 );
    specs->addWidget( pb_removeAllbutLast, s_row,   0, 1, 3 );
-   
+
    specs->addWidget( pb_include,      s_row++, 3, 1, 3 );
    specs->addWidget( lb_edit,         s_row++, 0, 1, 6 );
    specs->addWidget( lb_edtrsp,       s_row,   0, 1, 3 );
@@ -1778,27 +1802,27 @@ pb_plateau->setVisible(false);
 
    QPushButton* pb_cancel  = us_pushbutton( tr( "Cancel" ) );
    pb_pass    = us_pushbutton( tr( "Accept New Baseline Corrections" ), false );
-   
+
    connect( pb_cancel, SIGNAL( clicked() ), SLOT( close_manual_edit()  ) );
    connect( pb_pass,   SIGNAL( clicked()    ),
 	    this,      SLOT  ( pass_values_bll() ) );
-   
+
    buttons->addWidget( pb_cancel );
    buttons->addWidget( pb_pass );
 
 
    // -- Hide && || disable some buttons ----
-   
+
    cb_triple      -> setEnabled( false );
    pb_investigator->hide();
    le_investigator->hide();
-   pb_load        ->hide(); 
+   pb_load        ->hide();
    pb_details     ->hide();
    pb_report      ->hide();
    lb_gaps        ->hide();
    ct_gaps        ->hide();
    pb_nextChan    ->hide();
-   
+
    lb_scan        ->hide();
    lb_from        ->hide();
    lb_to          ->hide();
@@ -1823,12 +1847,12 @@ pb_plateau->setVisible(false);
    le_plateau     ->hide();
    lb_odlim       ->hide();
    ct_odlim       ->hide();
-   
+
    lb_baseline    ->hide();
    le_baseline    ->hide();
    le_edtrsp      ->hide();
    le_ltrng       ->hide();
-  
+
 //*NEW STUFF
 
    if ( exptype != "ABDE" )
@@ -1843,7 +1867,7 @@ pb_plateau->setVisible(false);
 
    // pb_meniscus    ->hide();
    // pb_dataRange   ->hide();
-   // pb_airGap      ->hide();  
+   // pb_airGap      ->hide();
 
    pb_noise       ->hide();
    pb_residuals   ->hide();
@@ -1854,20 +1878,20 @@ pb_plateau->setVisible(false);
    pb_spikes      ->hide();
    pb_undo        ->hide();
    pb_write       ->hide();
-   
+
    // pb_reset       ->hide();
    // pb_help        ->hide();
    // pb_accept      ->hide();
 
    //---------------------
-      
+
 
    // Plot layout on right side of window
-   plot = new US_Plot( data_plot, 
+   plot = new US_Plot( data_plot,
          tr( "Absorbance Data" ),
          tr( "Radius (in cm)" ), tr( "Absorbance" ),
          true, "", "rainbow" );
-   
+
    data_plot->setMinimumSize( 600, 400 );
 
    data_plot->enableAxis( QwtPlot::xBottom, true );
@@ -1890,7 +1914,7 @@ pb_plateau->setVisible(false);
    top ->addLayout( main );
 
    qDebug() << "US_Edit manual setup 1";
-   
+
    reset();
 
    qDebug() << "US_Edit manual setup 2";
@@ -1925,7 +1949,7 @@ pb_plateau->setVisible(false);
    includes      = editParams_includes;
    bl_corr_slope      = 0.0;
    bl_corr_yintercept = 0.0;
-  
+
    //replot
    plot_range_and_blc();
    pb_baseline_correct -> setEnabled( true );
@@ -1945,6 +1969,15 @@ pb_plateau->setVisible(false);
 // Constructor
 US_Edit::US_Edit() : US_Widgets()
 {
+   pb_removeAllbutLast = us_pushbutton( tr( "Remove All but Last" ), true );
+   pb_baseline_correct = us_pushbutton( tr( "Correct Baseline" ), false );
+   pb_bll_modify       = us_pushbutton( tr( "Modify Baseline Correction for Selected Triple" ), false );
+   lb_baseline_correct = us_banner( tr( "Linear Baseline Correction" ) );
+   lb_bll_slope        = us_label( tr( "Slope:" ), -1 );
+   le_bll_slope        = us_lineedit( "", 1, true );
+   lb_bll_intercept    = us_label( tr( "Y-intercept:" ), -1 );
+   le_bll_intercept    = us_lineedit( "", 1, true );
+   pb_pass             = us_pushbutton( tr( "Accept Changes for a Channel" ), false );
    check        = US_Images::getIcon( US_Images::CHECK );
    invert       = 1.0;
    all_edits    = false;
@@ -1966,9 +1999,9 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
    us_edit_auto_mode_manual_bll = false;
    all_loaded = false;
    is_spike_auto = false;
- 
+
 //usmode = false;
- 
+
    setWindowTitle( tr( "Edit UltraScan Data" ) );
    setPalette( US_GuiSettings::frameColor() );
 
@@ -1999,8 +2032,8 @@ DbgLv(1) << " 0)gap_fringe" << gap_fringe;
       pb_investigator->setEnabled( false );
 
    int     id      = US_Settings::us_inv_ID();
-   QString number  = ( id > 0 ) ? 
-      QString::number( US_Settings::us_inv_ID() ) + ": " 
+   QString number  = ( id > 0 ) ?
+      QString::number( US_Settings::us_inv_ID() ) + ": "
       : "";
    le_investigator = us_lineedit( number + US_Settings::us_inv_name(),
                                   1, true );
@@ -2104,7 +2137,7 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    // Scan Controls
    QLabel* lb_scan = us_banner( tr( "Scan Controls" ) );
-   
+
    // Scans
    QLabel* lb_from = us_label(  tr( "Scan Focus from:" ), -1 );
    lb_from->setAlignment( Qt::AlignVCenter | Qt::AlignRight );
@@ -2117,14 +2150,14 @@ lambdas << "250" << "350" << "450" << "550" << "580" << "583" << "650";
 
    ct_to          = us_counter( 3, 0.0, 0.0 ); // Update range upon load
    ct_to->setSingleStep( 1 );
-   
+
    // Exclude and Include pushbuttons
    pb_excludeRange = us_pushbutton( tr( "Exclude Scan Range" ), false );
    pb_exclusion    = us_pushbutton( tr( "Exclusion Profile" ),  false );
    pb_edit1       = us_pushbutton( tr( "Edit Single Scan" ), false );
    pb_include     = us_pushbutton( tr( "Include All" ), false );
 
-   // Edit controls 
+   // Edit controls
    QLabel* lb_edit = us_banner( tr( "Edit Controls" ) );
 
    // Edit Triple:Speed display (Equilibrium only)
@@ -2160,18 +2193,18 @@ pb_plateau->setVisible(false);
    le_baseline    = us_lineedit( "", 1, true );
 
 //*NEW STUFF
-//QLabel* 
+//QLabel*
    lb_dataStart   = us_label(      tr( "Data Start:" ), -1 );
-//QLineEdit* 
+//QLineEdit*
    le_dataStart   = us_lineedit( "", 1, true );
-//QPushButton* 
+//QPushButton*
    //pb_dataEnd     = us_pushbutton( tr( "Specify Range/End:" ), false );
    pb_dataEnd     = us_pushbutton( tr( "Specify Top/Bottom:" ), false );
-//QLineEdit* 
+//QLineEdit*
    le_dataEnd     = us_lineedit( "", 1, false );
-//QLabel* 
+//QLabel*
    lb_plateau     = us_label(      tr( "Plateau:" ), -1 );
-//QPushButton* 
+//QPushButton*
    pb_nextChan    = us_pushbutton( tr( "Next Triple" ), false );
 //*NEW STUFF
    // OD Limit
@@ -2207,7 +2240,7 @@ pb_plateau->setVisible(false);
    connect( pb_investigator, SIGNAL( clicked() ),
                              SLOT  ( sel_investigator()         ) );
    connect( pb_load,         SIGNAL( clicked() ), SLOT( load()  ) );
-   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple,       SIGNAL( currentIndexChanged( int ) ),
                              SLOT  ( new_triple         ( int ) ) );
    connect( pb_exclusion,    SIGNAL( clicked() ), SLOT( exclusion()     ) );
    connect( pb_edit1,        SIGNAL( clicked() ), SLOT( edit_scan()     ) );
@@ -2336,11 +2369,11 @@ pb_plateau->setVisible(false);
    buttons->addWidget( pb_accept );
 
    // Plot layout on right side of window
-   plot = new US_Plot( data_plot, 
+   plot = new US_Plot( data_plot,
          tr( "Absorbance Data" ),
          tr( "Radius (in cm)" ), tr( "Absorbance" ),
          true, "", "rainbow" );
-   
+
    data_plot->setMinimumSize( 600, 400 );
 
    data_plot->enableAxis( QwtPlot::xBottom, true );
@@ -2384,7 +2417,7 @@ void US_Edit::sel_investigator( void )
 
    QString inv_text = QString::number( investigator ) + ": "
                       +  US_Settings::us_inv_name();
-   
+
    le_investigator->setText( inv_text );
 }
 
@@ -2455,7 +2488,7 @@ void US_Edit::reset( void )
    cb_triple->disconnect();
 
    qDebug() << "reset 2";
-   
+
    data_plot->detachItems( QwtPlotItem::Rtti_PlotCurve );
    data_plot->detachItems( QwtPlotItem::Rtti_PlotMarker );
    v_line = NULL;
@@ -2469,7 +2502,7 @@ void US_Edit::reset( void )
    qDebug() << "reset 4";
    data_plot->replot();
    qDebug() << "reset 5";
-   
+
    // Disable pushbuttons
    pb_details     ->setEnabled( false );
 
@@ -2477,12 +2510,12 @@ void US_Edit::reset( void )
    pb_exclusion   ->setEnabled( false );
    pb_include     ->setEnabled( false );
    pb_edit1       ->setEnabled( false );
-   
+
    pb_meniscus    ->setEnabled( false );
    pb_airGap      ->setEnabled( false );
 //   pb_dataRange   ->setEnabled( false );
 //   pb_plateau     ->setEnabled( false );
-   
+
    pb_noise       ->setEnabled( false );
    pb_residuals   ->setEnabled( false );
    pb_spikes      ->setEnabled( false );
@@ -2491,7 +2524,7 @@ void US_Edit::reset( void )
    pb_reviewep    ->setEnabled( false );
    pb_nexteqtr    ->setEnabled( false );
    pb_undo        ->setEnabled( false );
-   
+
    pb_report      ->setEnabled( false );
    pb_float       ->setEnabled( false );
 
@@ -2499,7 +2532,7 @@ void US_Edit::reset( void )
      pb_write       ->setEnabled( true );
    else
      pb_write       ->setEnabled( false );
-   
+
    ck_writemwl    ->setEnabled( false );
 
    qDebug() << "reset 6";
@@ -2568,7 +2601,7 @@ void US_Edit::reset( void )
    qDebug() << "reset 7";
    connect_mwl_ctrls( true );
    qDebug() << "reset 8";
-   
+
    set_pbColors( NULL );
    lb_triple->setText( tr( "Cell / Channel / Wavelength" ) );
    qDebug() << "reset 9";
@@ -2613,7 +2646,7 @@ void US_Edit::reset_triple( void )
        le_bll_slope     ->setText( "" );
        le_bll_intercept ->setText( "" );
      }
-   
+
    if ( dataType == "IP" )
       ct_gaps->setValue( 0.4 );
    else
@@ -2642,8 +2675,8 @@ void US_Edit::reset_triple( void )
 
 // Display run details
 void US_Edit::details( void )
-{  
-   US_RunDetails2* dialog 
+{
+   US_RunDetails2* dialog
       = new US_RunDetails2( allData, runID, workingDir, triples );
    dialog->exec();
    qApp->processEvents();
@@ -2655,7 +2688,7 @@ void US_Edit::gap_check( void )
 {
    int threshold = (int)ct_gaps->value();
    gap_thresh    = ct_gaps->value();
-            
+
    US_DataIO::Scan  s;
    QString          gaps;
 
@@ -2681,7 +2714,7 @@ void US_Edit::gap_check( void )
          int byte = i / 8;
          int bit  = i % 8;
 
-         if ( s.interpolated[ byte ]  &  1 << ( 7 - bit ) ) 
+         if ( s.interpolated[ byte ]  &  1 << ( 7 - bit ) )
            gapLength++;
          else
            gapLength = 0;
@@ -2694,7 +2727,7 @@ void US_Edit::gap_check( void )
       }
 
       if ( maxGap >= threshold )
-      { 
+      {
          QwtPlotCurve* curve         = NULL;
          bool          deleteCurrent = false;
 
@@ -2703,7 +2736,7 @@ void US_Edit::gap_check( void )
 
          QString         seconds = QString::number( s.seconds );
          QwtPlotItemList items   = data_plot->itemList();
-         
+
          for ( int i = 0; i < items.size(); i++ )
          {
             if ( items[ i ]->rtti() == QwtPlotItem::Rtti_PlotCurve )
@@ -2740,31 +2773,31 @@ void US_Edit::gap_check( void )
             QMessageBox box;
 
             box.setWindowTitle( tr( "Excessive Scan Gaps Detected" ) );
-            
+
             double radius = data.xvalues[ 0 ] + location * s.delta_r;
-            
-            gaps = tr( "Scan " ) 
-                 + QString::number( rawScanNumber ) 
-                 + tr( " has a maximum reading gap of " ) 
-                 + QString::number( maxGap ) 
-                 + tr( " starting at radius " ) 
+
+            gaps = tr( "Scan " )
+                 + QString::number( rawScanNumber )
+                 + tr( " has a maximum reading gap of " )
+                 + QString::number( maxGap )
+                 + tr( " starting at radius " )
                  + QString::number( radius, 'f', 3 );
 
             box.setText( gaps );
             box.setInformativeText( tr( "Delete?" ) );
 
-            QPushButton* pb_delete = box.addButton( tr( "Delete" ), 
+            QPushButton* pb_delete = box.addButton( tr( "Delete" ),
                   QMessageBox::YesRole );
-         
-            QPushButton* pb_deleteAll = box.addButton( tr( "Delete All" ), 
+
+            QPushButton* pb_deleteAll = box.addButton( tr( "Delete All" ),
                   QMessageBox::AcceptRole );
-         
-            QPushButton* pb_skip = box.addButton( tr( "Skip" ), 
+
+            QPushButton* pb_skip = box.addButton( tr( "Skip" ),
                   QMessageBox::NoRole );
-         
-            QPushButton* pb_cancel = box.addButton( tr( "Cancel" ), 
+
+            QPushButton* pb_cancel = box.addButton( tr( "Cancel" ),
                   QMessageBox::RejectRole );
-         
+
             box.setEscapeButton ( pb_cancel );
             box.setDefaultButton( pb_delete );
 
@@ -2779,7 +2812,7 @@ void US_Edit::gap_check( void )
                deleteCurrent = true;
             }
 
-            else 
+            else
             {
                // Uncolor scan
                p.setColor( Qt::yellow );
@@ -2792,7 +2825,7 @@ void US_Edit::gap_check( void )
 
             if ( box.clickedButton() == pb_skip )
                continue;
-            
+
             if ( box.clickedButton() == pb_cancel )
                return;
          }
@@ -2807,7 +2840,7 @@ void US_Edit::gap_check( void )
             ct_from->setMaximum( includes.size() );
          }
       }
-                             
+
       scanNumber++;
    }
 }
@@ -2824,7 +2857,7 @@ void US_Edit::load_auto( QMap < QString, QString > & details_at_editing )
   channels_to_analyse.clear();
   triple_to_edit.clear();
   triples_skip_analysis.clear();
-  
+
   // analysis stages
   job1run     = false;
   job2run     = false;
@@ -2834,11 +2867,11 @@ void US_Edit::load_auto( QMap < QString, QString > & details_at_editing )
   job3auto    = false;
   job6run_pcsa= false;
   /////////////////////////
-  
+
   details_at_editing_local = details_at_editing;
-  
+
   le_status->setText( tr( "Loading data ..." ) );
-  
+
   // QList< DataDesc_auto >  sdescs_auto;
   // datamap.clear();
 
@@ -2850,16 +2883,16 @@ void US_Edit::load_auto( QMap < QString, QString > & details_at_editing )
 
   dataSource          = details_at_editing[ "dataSource" ];
   simulated_data      = false;
-  
+
   qDebug() << "autoflowID_passed, dataSource, ProtocolName_auto, autoflow_expType : "
 	   << autoflowID_passed << dataSource << ProtocolName_auto << autoflow_expType;
-  
+
   // Deal with different filenames if any.... //////////////////////////
   filename_runID_passed = details_at_editing[ "filename" ];
   runType_combined_IP_RI = false;
 
   runTypes_map.clear();
-  
+
   if ( filename_runID_passed.contains(",") && filename_runID_passed.contains("IP") && filename_runID_passed.contains("RI") )
     {
       for ( int i = 0 ; i < filename_runID_passed.split(",").count(); ++i )
@@ -2868,12 +2901,12 @@ void US_Edit::load_auto( QMap < QString, QString > & details_at_editing )
 
 	  qDebug() << "Filename: " << filename_runID_passed.split(",")[i];
 	}
-      
+
       runType_combined_IP_RI = true;
     }
   else
     filename_runID_auto = filename_runID_passed;
-    
+
   qDebug() << "runType_combined_IP_RI: " << runType_combined_IP_RI;
 
   //ALEXEY: create filename_runID_auto_base name
@@ -2881,15 +2914,15 @@ void US_Edit::load_auto( QMap < QString, QString > & details_at_editing )
     {
       QString filename_runID_auto_base_temp = filename_runID_passed.split(",")[0];
       int pos = filename_runID_auto_base_temp.lastIndexOf(QChar('-'));
-      
+
       filename_runID_auto_base = filename_runID_auto_base_temp.left( pos );
 
       qDebug() << "IN EDIT - filename_base for combined runs: " << filename_runID_auto_base;
-      
+
     }
-    
+
   ///////////////////////////////////////////////////////////////////////
-  
+
   qDebug() << "autoflowID, intensityID, autoflowStatusID : " << autoflowID_passed << details_at_editing[ "intensityID" ] << autoflowStatusID;
   qDebug() << "AT EDIT_DATA: filename, idInv: " << filename_runID_passed << ", " << idInv_auto;
 
@@ -2914,7 +2947,7 @@ void US_Edit::load_auto( QMap < QString, QString > & details_at_editing )
       le_bll_slope        -> setVisible( true );
       le_bll_intercept    -> setVisible( true );
     }
-  
+
 }
 
 //Slot to process optics type...
@@ -2935,13 +2968,13 @@ void US_Edit::process_optics_auto( )
 
   //abde
   edited_triples_abde. clear();
-  
+
   //Read centerpiece names from protocol:
   centerpiece_names.clear();
-  
+
   QList< DataDesc_auto >  sdescs_auto;
   datamap.clear();
-  
+
   scan_db_auto();
   sdescs_auto  = datamap.values();
   load_db_auto( sdescs_auto );
@@ -2953,33 +2986,33 @@ DbgLv(1) << "Ld: runID" << runID << "wdir" << workingDir;
    sd_knts   .clear();
    cb_triple->clear();
    files     .clear();
-   
+
    if ( triples.size() == 0 )
    {
       QMessageBox::warning( this,
             tr( "No Files Found" ),
-            tr( "There were no files of the form *.auc\n"  
+            tr( "There were no files of the form *.auc\n"
                 "found in the specified directory." ) );
       return;
    }
 
    qDebug() << "IN PROCESS OPTICS: triples_size() " << triples.size();
-     
+
    cb_triple->addItems( triples );
 
    // Debug
    for (int index = 0; index < cb_triple->count(); index++)
      qDebug() << cb_triple->itemText(index);
-   
-   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+
+   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                        SLOT  ( new_triple_auto    ( int ) ) );
    triple_index = 0;
    data_index   = 0;
-   
+
    le_info->setText( runID );
 
    data     = allData[ 0 ];
-   dataType = QString( QChar( data.type[ 0 ] ) ) 
+   dataType = QString( QChar( data.type[ 0 ] ) )
             + QString( QChar( data.type[ 1 ] ) );
 
    if ( dataType == "IP" )
@@ -2991,13 +3024,13 @@ DbgLv(1) << "Ld: runID" << runID << "wdir" << workingDir;
       ct_gaps->setValue     ( 0.4 );
       ct_gaps->setNumButtons( 3 );
 
-      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ), 
+      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ),
                         SLOT  ( set_fringe_tolerance( double ) ) );
    }
    else
    {
       lb_gaps->setText( tr( "Threshold for Scan Gaps" ) );
-      
+
       ct_gaps->disconnect   ();
       ct_gaps->setRange     ( 10.0, 100.0 );
       ct_gaps->setSingleStep( 10.0 );
@@ -3020,7 +3053,7 @@ DbgLv(1) << "Ld: runtype" << runtype;
       files << file;
 
       qDebug() << "EDIT: file -- " << file;
-      
+
       // Save pointers as initial output data vector
       outData << &allData[ trx ];
 
@@ -3100,7 +3133,7 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       }
 
       QStringList query;
-      query << "get_experiment_info_by_runID" << runID 
+      query << "get_experiment_info_by_runID" << runID
             << QString::number( US_Settings::us_inv_ID() );
 
       dbP->query( query );
@@ -3130,9 +3163,9 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       lb_rpms    ->setVisible( true  );
       cb_rpms    ->setVisible( true  );
       pb_plateau ->setVisible( false );
-      le_plateau ->setVisible( false ); 
-      lb_baseline->setVisible( false ); 
-      le_baseline->setVisible( false ); 
+      le_plateau ->setVisible( false );
+      lb_baseline->setVisible( false );
+      le_baseline->setVisible( false );
       lb_edtrsp  ->setVisible( true  );
       le_edtrsp  ->setVisible( true  );
       pb_reviewep->setVisible( true  );
@@ -3210,7 +3243,7 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       connect( pb_priorEdits, SIGNAL( clicked() ), SLOT( prior_equil() ) );
       plot_scan();
 
-      connect( cb_rpms,   SIGNAL( currentIndexChanged( int ) ), 
+      connect( cb_rpms,   SIGNAL( currentIndexChanged( int ) ),
                           SLOT  ( new_rpmval         ( int ) ) );
    }
 
@@ -3219,15 +3252,15 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       bool notMwl  = ( nwaveln < 3 );
 
       qDebug() << "notMWL, nwaveln: " << notMwl << ", " << nwaveln;
-	
+
       lb_rpms    ->setVisible( false );
       cb_rpms    ->setVisible( false );
 //      pb_plateau ->setVisible( true  );
-      le_plateau ->setVisible( true  ); 
+      le_plateau ->setVisible( true  );
       // lb_baseline->setVisible( notMwl );
       // le_baseline->setVisible( notMwl );
       lb_baseline->setVisible( true );
-      le_baseline->setVisible( true );     
+      le_baseline->setVisible( true );
       lb_edtrsp  ->setVisible( false );
       le_edtrsp  ->setVisible( false );
       pb_reviewep->setVisible( false );
@@ -3449,7 +3482,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
       cb_triple->disconnect();
       cb_triple->clear();
       cb_triple->addItems( celchns );
-      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                           SLOT  ( new_triple_auto    ( int ) ) );
       pb_nextChan->setEnabled( celchns.size() > 1 );
 
@@ -3462,7 +3495,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
    else
    {
      qDebug() << "LOADING 1";
-     
+
      //new_triple_auto( 0 );                             //ALEXEY <--- new_triple_auto()
      pb_nextChan->setEnabled( cb_triple->count() > 1 );
 
@@ -3503,7 +3536,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
    connect( ct_odlim,  SIGNAL( valueChanged       ( double ) ),
             this,      SLOT  ( od_radius_limit    ( double ) ) );
 
-   qDebug() << "IS MWL? " << isMwl; 
+   qDebug() << "IS MWL? " << isMwl;
    show_mwl_controls( isMwl );
 
    /***************** TESTING ******************************************/
@@ -3537,17 +3570,17 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 	    <<  job4run << ", "
 	    <<  job5run << ", "
 	    <<  job6run_pcsa;
-   
+
    //Debug
    for (int i=0; i<cb_triple->count(); i++)
      qDebug() << "Triple, AprofParms: " << cb_triple->itemText( i )  << ", " << aprofileParameters[i];
 
-   
+
    qDebug() << "DATA SIZE: " << outData.count();
 
    // if ( !isMwl )
    //   {
-   //     qDebug() << "Not MWL? " << isMwl << "hiding mwl plot controls..."; 
+   //     qDebug() << "Not MWL? " << isMwl << "hiding mwl plot controls...";
    //     lb_lplot ->setHidden( true );
    //     cb_lplot ->setHidden( true );
    //     pb_larrow->setHidden( true );
@@ -3571,7 +3604,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
        triple_plot_first_time[ trx ] = 0;
      }
 
-   
+
    //for ( int trx = 0; trx < triples.size(); trx++ )
    //Go over triples: for IP-MWL data, find reference wvl
    //find auto-meniscus porisions
@@ -3585,17 +3618,17 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
        QString triple_channel_       = triple_name_list_[1].trimmed();
        QString channelname_        = triple_cell_number_ + triple_channel_;
        qDebug() << "channelname_: " << channelname_ ;
-       
+
        if ( dataSource. contains("DiskAUC:Absorbance") && channelname_.contains("S")  )
 	 {
 	   channelname_ = channelname_.replace("S","A");
 	   simulated_data = true;
 	 }
-       
+
        le_status->setText( tr( "Setting edit controls for channel %1" ).arg( triple_name ) );
        qApp->processEvents();
 
-      
+
        //Debug
        for ( int g=0; g < expi_wvlns.size(); ++g )
 	 qDebug() << "MWL wavelengths for triple: " << triple_name << expi_wvlns[ g ];
@@ -3610,7 +3643,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 	   //Debug
 	   for ( int g=0; g < expi_wvlns.size(); ++g )
 	     qDebug() << "MWL wavelengths for triple: " << triple_name << expi_wvlns[ g ];
-	   
+
 	   //Check here if info for EDIT wvl is set in the AProfile:
 	   //    if yes, identify wvl for current triple:
 	   //    otherwise, use current plotndx
@@ -3618,12 +3651,12 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 	   QString channel_desc = triple_name;
 	   channel_desc.replace(" / ",".");
 	   QString opsys = QString("UV/vis");
-	   
+
 	   if ( isSet_edit_info_for_channel( channel_desc,  opsys ) )
 	     {
 	       //iwavl = wvl_from_aprofile;
 	       channel_desc.replace(".","");
-	       
+
 	       QMap<QString, QString>::iterator jjj;
 	       for ( jjj = triple_to_edit.begin(); jjj != triple_to_edit.end(); ++jjj )
 		 {
@@ -3634,7 +3667,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 
 		       iwavl_edit_ref[ trx ] =  wvl_set_edit.toInt();
 		       qDebug() << "Reference wvl --  " <<  wvl_set_edit << " was identified using AProfile";
-		       		       
+
 		       break;
 		     }
 		 }
@@ -3658,12 +3691,12 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 
 	       //TEST:: IMPORTANT ** comment out when done with testing !!
 	       //plotndx = 2;
-	       
+
 	       iwavl_edit_ref[ trx ]       = expi_wvlns[ plotndx ];
 	       iwavl_edit_ref_index[ trx ] = plotndx;
 	       qDebug() << "Wvl index && value -- " <<  iwavl_edit_ref_index[ trx ] << iwavl_edit_ref[ trx ];
 	     }
-	   
+
 	   data_index   = mwl_data.data_index( iwavl_edit_ref[ trx ], trx );
 
 	   //Debug
@@ -3676,53 +3709,53 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 	   qDebug() << "#Wvls for " << triple_name << trx << ": " << num_wvls;
 	   for (int rr=0; rr<wvs_temp.size(); ++rr )
 	     qDebug() << "wvls ARE -- "  << wvs_temp[ rr ];
-	   
+
 	 }
        else
 	 index_data_auto( trx );
 
        qDebug() << "Data index: " << data_index;
-       
+
        edata          = outData[ data_index ];
        data           = *edata;
-       
+
        //QString rawGUID_test          = US_Util::uuid_unparse( (unsigned char*)data.rawGUID );
        //qDebug() << "Current rawData: rawGUID: " <<  rawGUID_test << ", filename: " << files[ trx ] << ", editGUID: " << editGUIDs[ trx ];
 
-       //Find meniscus position based on the read parameters for centerpiece channel (trx) && aprofile for each channel 
+       //Find meniscus position based on the read parameters for centerpiece channel (trx) && aprofile for each channel
        read_centerpiece_params( trx );
 
        //range_right = 7.0;
        aprofile_volume = aprofileParameters[ trx ][0].toDouble();        //<-- From Aprofile
        range_right   = aprofileParameters[ trx ][1].toDouble();           //<-- From Aprofile
        qDebug() << "Range_right && Loading volume FROM AProfile: " << triple_name << ", " << range_right << ", " << aprofile_volume;
-       
+
        //Find meniscus
        if ( dataType != "IP" )
 	 {
 	   lb_airGap->setHidden( true );
 	   le_airGap->setHidden( true );
 	   pb_airGap->setHidden( true );
-	   
+
 	   meniscus = find_meniscus_auto();
-             
+
 	   le_meniscus ->setText( QString::number( meniscus,   'f', 3 ) );
-	   
+
 	   range_left    = meniscus + _RNGLEFT_OFFSET_;
 	   le_dataStart->setText( QString::number( range_left, 'f', 3 ) );
-	   
-	   
+
+
 	   le_dataEnd  ->setText( QString::number( range_right, 'f', 3 ) );
 	   // plateau      = range_right - _PLATEAU_OFFSET_;
 	   // le_plateau  ->setText( QString::number( plateau,     'f', 3 ) );
-	   
+
 	   step = PLATEAU;
 	   //plot_range();
 	   next_step();
-	   
+
 	   //ALEXEY: here create a QMap to couple current triple AND meniscus, ranges, plateau and baseline;
 	   // then, use this QMap when plotting plot_range() in new_triple_auto()...
-	   
+
 	   triple_info.clear();
 	   triple_info <<  QString::number(meniscus)
 		       <<  QString::number(range_left)
@@ -3731,7 +3764,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 		       <<  QString::number(baseline)
 		       <<  QString::number(baseline_od)
 		       <<  QString("spike_false");
-	   
+
 	   //ALEXEY: get all cb_triple listbox items (texts)...
 	   editProfile[ triple_name ] = triple_info;
 
@@ -3751,9 +3784,9 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 		 }
 	       ++ci;
 	     }
-	   	   
+
 	   qDebug() << triple_name  << ", " << triple_info;
-	   
+
 	 }
        else
 	 {
@@ -3768,35 +3801,35 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 
 	   //find meniscus
 	   meniscus = find_meniscus_interference_auto();
-	   
+
 	   //find airGap && adjust interference_data
 	   airGap_values = find_airGap_interference_auto();
 
 	   airGap_left  = airGap_values[0];
 	   airGap_right = airGap_values[1];
-	   
+
 	   US_DataIO::EditValues  edits;
 	   edits.airGapLeft  = airGap_left;
 	   edits.airGapRight = airGap_right;
 
-	   	   
+
 	   QList< int > excludes;
-           
+
 	   for ( int i = 0; i < data.scanData.size(); i++ )
 	     if ( ! includes.contains( i ) ) edits.excludes << i;
-	   
+
 	   DbgLv(1) << "AGap: L R" << airGap_left << airGap_right << " AdjIntf";
 	   US_DataIO::adjust_interference( data, edits );
-	   
+
 	   // Un-zoom
 	   if ( plot->btnZoom->isChecked() )
 	     plot->btnZoom->setChecked( false );
-	   
+
 	   // Display the data
 	   QString wkstr;
-	   le_airGap->setText( wkstr.sprintf( "%.3f - %.3f", 
+	   le_airGap->setText( wkstr.sprintf( "%.3f - %.3f",
 					      airGap_left, airGap_right ) );
-	   
+
 	   step          = RANGE;
 	   range_left    = meniscus + _RNGLEFT_OFFSET_;
 
@@ -3810,19 +3843,19 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 	   edits.gapTolerance = ct_gaps->value();
 
 	   qDebug() << "RANGE: edits.gapTolerance: " << edits.gapTolerance;
-	   
+
 	   US_DataIO::calc_integral( data, edits );
-	   
-	   	   
+
+
 	   step = PLATEAU;
 	   //plot_range();              //ALEXEY <--- here applies the gap removal
 	   next_step();
 
 	   //qApp->processEvents();
-	   
+
 	   //ALEXEY: here create a QMap to couple current triple AND meniscus, ranges, plateau and baseline;
 	   // then, use this QMap when plotting plot_range() in new_triple_auto()...
-	   
+
 	   triple_info.clear();
 	   triple_info <<  QString::number(meniscus)
 		       <<  QString::number(range_left)
@@ -3833,7 +3866,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 		       <<  QString("spike_false")
 		       <<  QString::number(airGap_left)
 		       <<  QString::number(airGap_right);
-	   
+
 	   //ALEXEY: get all cb_triple listbox items (texts)...
 	   editProfile[ triple_name ] = triple_info;
 
@@ -3873,7 +3906,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 
    if ( isMwl )
      {
-       new_triple_auto( 0 );     //ALEXEY: is it right ? 
+       new_triple_auto( 0 );     //ALEXEY: is it right ?
        //plot_mwl();
        pb_spikes   ->setEnabled( true );
      }
@@ -3889,7 +3922,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
    else
      pb_write->setEnabled( true );
    pb_emanual->setEnabled( true );
-   pb_undo ->setEnabled( false ); 
+   pb_undo ->setEnabled( false );
 
    le_status->setText( tr( "Edit controls set" ) );
 
@@ -3901,9 +3934,9 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 void US_Edit::reset_editdata_panel( void )
 {
   qDebug() << "Resetting EDIT_DATA panel BEFORE going to Manage runs... ";
-  
+
   reset( );
-  
+
   qDebug() << "EDIT_DATA reset ..";
 }
 
@@ -3914,12 +3947,12 @@ void US_Edit::read_aprofile_data_from_aprofile()
   aprof_channel_to_scans.clear();
 
   QString aprofile_xml;
-  
+
   // Check DB connection
   US_Passwd pw;
   QString masterPW = pw.getPasswd();
   US_DB2 db( masterPW );
-  
+
   if ( db.lastErrno() != US_DB2::OK )
     {
       QMessageBox::warning( this, tr( "Connection Problem" ),
@@ -3929,11 +3962,11 @@ void US_Edit::read_aprofile_data_from_aprofile()
 
   // qDebug() << "AProfGUID: " << AProfileGUID;
 
-    
+
   QStringList qry;
   qry << "get_aprofile_info" << AProfileGUID;
   db.query( qry );
-  
+
   while ( db.next() )
     {
       //currProf.aprofID     = db.value( 0 ).toInt();
@@ -3942,7 +3975,7 @@ void US_Edit::read_aprofile_data_from_aprofile()
     }
 
   //qDebug() << "aprofile_xml: " <<  aprofile_xml;
-  
+
   if ( !aprofile_xml.isEmpty() )
     {
       QXmlStreamReader xmli( aprofile_xml );
@@ -3966,7 +3999,7 @@ void US_Edit::read_aprofile_data_from_aprofile()
 	channelname = channelname.replace("S","A");
 
       qDebug() << "channelname2: " << channelname ;
-      
+
       //iterate over aprofile_channel_to_parms QMap and check if channel name is a part of triple_name:
       QMap<QString, QStringList>::const_iterator i = aprof_channel_to_parms.constBegin();
       while (i != aprof_channel_to_parms.constEnd())
@@ -3992,26 +4025,26 @@ void US_Edit::read_centerpiece_names_from_protocol()
   US_Passwd pw;
   QString masterPW = pw.getPasswd();
   US_DB2 db( masterPW );
-  
+
   if ( db.lastErrno() != US_DB2::OK )
     {
       QMessageBox::warning( this, tr( "Connection Problem" ),
 			    tr( "Read protocol: Could not connect to database \n" ) + db.lastError() );
       return;
     }
-     
+
   QString xmlstr( "" );
 
   US_ProtocolUtil::read_record_auto( ProtocolName_auto, idInv_auto.toInt(),  &xmlstr, NULL, &db );
 
   qDebug() << "Protocol READ !!! ";
-  
+
   QXmlStreamReader xmli( xmlstr );
 
   while( ! xmli.atEnd() )
     {
       xmli.readNext();
-      
+
       if ( xmli.isStartElement() )
 	{
 	  QString ename   = xmli.name().toString();
@@ -4052,10 +4085,10 @@ void US_Edit::read_centerpiece_names_from_protocol()
 	    }
 	  ++i;
 	}
-      
+
       //centerpiece_names[ trx ] = centerpiece_name;
     }
-  
+
 }
 
 bool US_Edit::readProtocolCells_auto( QXmlStreamReader& xmli )
@@ -4063,7 +4096,7 @@ bool US_Edit::readProtocolCells_auto( QXmlStreamReader& xmli )
   while( ! xmli.atEnd() )
     {
       QString ename   = xmli.name().toString();
-      
+
       if ( xmli.isStartElement() )
 	{
 	  if ( ename == "cell" )
@@ -4075,14 +4108,14 @@ bool US_Edit::readProtocolCells_auto( QXmlStreamReader& xmli )
 	      cell_to_centerpiece [ cell_id ] =  centerpiece;
 	    }
 	}
-      
+
       bool was_end    = xmli.isEndElement();  // Just read was End of element?
       xmli.readNext();                        // Read the next element
-      
+
       if ( was_end  &&  ename == "cells" )    // Break after "</cells>"
 	break;
     }
-  
+
   return ( ! xmli.hasError() );
 }
 
@@ -4092,7 +4125,7 @@ bool US_Edit::readProtocolAProfile_auto( QXmlStreamReader& xmli )
   while( ! xmli.atEnd() )
     {
       QString ename   = xmli.name().toString();
-      
+
       if ( xmli.isStartElement() )
 	{
 	  if ( ename == "aprofile" )
@@ -4101,17 +4134,17 @@ bool US_Edit::readProtocolAProfile_auto( QXmlStreamReader& xmli )
 	      //AProfileName   = attr.value( "name"  ).toString();
 	      AProfileGUID   = attr.value( "guid"  ).toString();
 	    }
-	  
+
 	  else
             break;
 	}
-      
+
       else if ( xmli.isEndElement()  &&  ename == "aprofile" )
 	break;
-      
+
       xmli.readNext();
     }
-  
+
   return ( ! xmli.hasError() );
 }
 
@@ -4125,10 +4158,10 @@ bool US_Edit::readAProfileBasicParms_auto( QXmlStreamReader& xmli )
   while( ! xmli.atEnd() )
     {
       QString ename   = xmli.name().toString();
-      
+
       if ( xmli.isStartElement() )
       {
-	
+
 	//QString ename   = xmli.name().toString();
 
 	if ( ename == "channel_parms" )
@@ -4137,24 +4170,24 @@ bool US_Edit::readAProfileBasicParms_auto( QXmlStreamReader& xmli )
 
 	    if ( attr.hasAttribute("load_volume") )
 	      {
-		
+
 		QString channel_name = attr.value( "channel" ).toString();
-				
+
 		QStringList aprof_parms;
 		aprof_parms << attr.value( "load_volume" ).toString()
 			    << attr.value( "data_end" ).toString();
-		
+
 		qDebug() << "READING aprof XML: " << channel_name << ", " << aprof_parms;
-		
+
 		aprof_channel_to_parms[ channel_name ] = aprof_parms;
-	       
+
 		//Read what channels to analyse:
 		if ( attr.hasAttribute("run") )
 		  {
 		    QString channel_desc = attr.value( "chandesc" ).toString();
 		    channels_to_analyse[ channel_desc ] = bool_flag( attr.value( "run" ).toString() );
 		  }
-		
+
 		//Read what triple selected for editing:
 		if ( attr.hasAttribute("wvl_edit") )
 		  {
@@ -4175,14 +4208,14 @@ bool US_Edit::readAProfileBasicParms_auto( QXmlStreamReader& xmli )
 		    QStringList scan_excl_pairs;
 		    scan_excl_pairs << attr.value( "scan_excl_begin" ).toString()
 				    << attr.value( "scan_excl_end" )  .toString();
-		    
+
 		    qDebug() << "READING aprof XML, scans excl.: " << channel_name << ", " << scan_excl_pairs;
-		    
+
 		    aprof_channel_to_scans[ channel_name ] = scan_excl_pairs;
 		  }
 	      }
 	  }
-	
+
 	else if ( ename == "job_2dsa" )
 	  {
             QXmlStreamAttributes attr = xmli.attributes();
@@ -4206,7 +4239,7 @@ bool US_Edit::readAProfileBasicParms_auto( QXmlStreamReader& xmli )
             QXmlStreamAttributes attr = xmli.attributes();
             job3run        = bool_flag( attr.value( "run" ).toString() );
             job3auto       = attr.value( "interactive" ).toString().toInt() == 0;
-	    	    
+
 	    qDebug() << "job3run:  " << job3run;
 	    qDebug() << "job3auto: " << job3auto;
 	  }
@@ -4235,19 +4268,19 @@ bool US_Edit::readAProfileBasicParms_auto( QXmlStreamReader& xmli )
 	    qDebug() << "job6run_pcsa: " << job6run_pcsa;
 	  }
       }
-      
+
       bool was_end    = xmli.isEndElement();  // Just read was End of element?
       xmli.readNext();                        // Read the next element
 
       if ( was_end  &&  ename == "p_pcsa" )   // Break after "</p_pcsa>"
          break;
-      
-      // else if ( ename == "p_2dsa" )       //Stop reading AProfile when 2DSA section reached 
+
+      // else if ( ename == "p_2dsa" )       //Stop reading AProfile when 2DSA section reached
       //  break;
-	
+
       //}
     }
-  
+
   return ( ! xmli.hasError() );
 }
 
@@ -4271,14 +4304,14 @@ void US_Edit::read_centerpiece_params( int trx )
    US_Passwd pw;
    QString masterPW = pw.getPasswd();
    US_DB2 db( masterPW );
-   
+
    if ( db.lastErrno() != US_DB2::OK )
      {
        QMessageBox::warning( this, tr( "Connection Problem" ),
 			     tr( "Read protocol: Could not connect to database \n" ) + db.lastError() );
        return;
      }
-   
+
    //Establish correspondence btw centerpiece name & ID (centerpieceID)
    query.clear();
    query << "get_abstractCenterpiece_names";
@@ -4295,7 +4328,7 @@ void US_Edit::read_centerpiece_params( int trx )
 	   break;
 	 }
      }
-   
+
    //Get Centerpiece info
    query.clear();
    query << "get_abstractCenterpiece_info" << centerpieceID_read;
@@ -4326,7 +4359,7 @@ QVector<double> US_Edit::find_airGap_interference_auto()
   QVector< double > x_airGap_rights;
   double airGap_left_av  = 0;
   double airGap_right_av = 0;
-  
+
   // starting from meniscus position, go backwards and fit several points into staight line..
   // then, look at max deviation from it and find the onset of the airGap (in reverse order)
   // basically, repeat finding meniscus algorithm...
@@ -4338,11 +4371,11 @@ QVector<double> US_Edit::find_airGap_interference_auto()
   for ( int i = start_scan; i < end_scan; i++ )
     {
       US_DataIO::Scan*  s = &data.scanData[ i ];
-      
+
       double y_max_deviation = -1.0e99;
       double x_airGap_left;
       double x_airGap_right;
-     
+
       double right_fit    = meniscus - 0.02;
       int indexRight_fit  = data.xindex( right_fit );
       double left_fit     = right_fit - 0.02;
@@ -4357,7 +4390,7 @@ QVector<double> US_Edit::find_airGap_interference_auto()
       double sumXY = 0;
       double sumX2 = 0;
       int countPoints = 0;
-      
+
       for ( int j = indexLeft_fit; j <= indexRight_fit; j++ )
       {
 	double y_curr = s->rvalues[ j ] * invert;
@@ -4378,13 +4411,13 @@ QVector<double> US_Edit::find_airGap_interference_auto()
       double YInt  = yMean - Slope * xMean;
 
       ***************/
-      
+
       /********** TESTITNG *******************************************************/
       //Alternative: derive a curve passing through Left/Right indecies
       double Slope = (s->rvalues[ indexRight_fit ] * invert - s->rvalues[ indexLeft_fit ] * invert ) / ( data.xvalues[ indexRight_fit ] - data.xvalues[ indexLeft_fit ] );
       double YInt  = s->rvalues[ indexRight_fit ] * invert - Slope *  data.xvalues[ indexRight_fit ];
       /****************************************************************************/
-      
+
       //qDebug() << "y(x) = Slope * X + YInt: " << Slope << "*X + " <<  YInt;
 
       //Find the biggest y-deviation from a line fit
@@ -4419,7 +4452,7 @@ QVector<double> US_Edit::find_airGap_interference_auto()
 	    {
 	      x_airGap_right = x_curr - 0.02;
 	      x_airGap_left  = x_airGap_right - 0.02;
-	      break; 
+	      break;
 	    }
 	}
       x_airGap_lefts.push_back( x_airGap_left );
@@ -4434,10 +4467,10 @@ QVector<double> US_Edit::find_airGap_interference_auto()
       airGap_left_av  += x_airGap_lefts[ i ];
       airGap_right_av += x_airGap_rights[ i ];
     }
-  
+
   airGap_left_av  /= x_airGap_lefts.size();
   airGap_right_av /= x_airGap_rights.size();
-  
+
   // airGap_vals.push_back(airGap_left_av);
   // airGap_vals.push_back(airGap_right_av);
 
@@ -4445,47 +4478,47 @@ QVector<double> US_Edit::find_airGap_interference_auto()
   airGap_vals.push_back(5.85);
   airGap_vals.push_back(5.90);
 
-  
+
   qDebug() << "INTERFERENCE: airGaps: " << airGap_vals;
-    
+
   return airGap_vals;
 }
 
 double US_Edit::find_meniscus_interference_auto()
 {
-  double bottom_db     = centerpiece_info[ "bottom" ].toDouble(); 
+  double bottom_db     = centerpiece_info[ "bottom" ].toDouble();
   double pathlength_db = centerpiece_info[ "pathlen" ].toDouble();
   double angle_db      = centerpiece_info[ "angle" ].toDouble();
 
   //double aprofile_volume   = 460; // Just an example - to be read from AProfile, will be global
-  
+
   double meniscus_init = sqrt( bottom_db*bottom_db - ( aprofile_volume*360/(1000*pathlength_db*angle_db*M_PI ) ) );     //Radians = Degrees * (M_PI/180.0)
-  
+
   qDebug() << "Meniscus_init: INTERFERENCE " << meniscus_init << ", " << bottom_db << ", " << pathlength_db << ", " << angle_db << ", " << M_PI;
-    
+
   double meniscus_av = 0;
   QVector< double > x_meniscuses;
-  
+
   // For each scan in the last ~20% of scans:
   int start_scan = int(0.8*data.scanData.size());
   int end_scan   = data.scanData.size();
 
-  qDebug() << "Scans for meniscus: start_scan, end_scan: " << start_scan << ", " << end_scan; 
-  
+  qDebug() << "Scans for meniscus: start_scan, end_scan: " << start_scan << ", " << end_scan;
+
   for ( int i = start_scan; i < end_scan; i++ )
     {
       US_DataIO::Scan*  s = &data.scanData[ i ];
-      
+
       double y_max_deviation = -1.0e99;
       double x_meniscus;
-     
+
       //double left_fit = 6.5;
       double left_fit = meniscus_init + (range_right - meniscus_init)*0.5;
-      
+
       int indexLeft_fit   = data.xindex( left_fit );
       int indexRight      = data.xindex( range_right );
-           
-      //qDebug() << "indexLeft_fit = " << indexLeft_fit << "; indexRight = " <<  indexRight; 
+
+      //qDebug() << "indexLeft_fit = " << indexLeft_fit << "; indexRight = " <<  indexRight;
 
 
       /**********************************
@@ -4495,7 +4528,7 @@ double US_Edit::find_meniscus_interference_auto()
       double sumXY = 0;
       double sumX2 = 0;
       int countPoints = 0;
-      
+
       for ( int j = indexLeft_fit; j <= indexRight; j++ )
       {
 	double y_curr = s->rvalues[ j ] * invert;
@@ -4521,7 +4554,7 @@ double US_Edit::find_meniscus_interference_auto()
       double Slope = (s->rvalues[ indexRight ] * invert - s->rvalues[ indexLeft_fit ] * invert ) / ( data.xvalues[ indexRight ] - data.xvalues[ indexLeft_fit ] );
       double YInt  = s->rvalues[ indexRight ] * invert - Slope *  data.xvalues[ indexRight ];
       /****************************************************************************/
-      
+
       //qDebug() << "y(x) = Slope * X + YInt: " << Slope << "*X + " <<  YInt;
 
       //Find the biggest y-deviation from a line fit
@@ -4553,11 +4586,11 @@ double US_Edit::find_meniscus_interference_auto()
 	  if( y_diff_abs > y_max_deviation * 1.5 )
 	    {
 	      x_meniscus = x_curr;
-	      break; 
+	      break;
 	    }
 	}
-      x_meniscuses.push_back( x_meniscus ); 
-      
+      x_meniscuses.push_back( x_meniscus );
+
     }
 
   //Find simple average position of the meniscus
@@ -4566,9 +4599,9 @@ double US_Edit::find_meniscus_interference_auto()
       meniscus_av += x_meniscuses[ i ];
       //qDebug() << "x_max: " << x_maxs[ i ] ;
     }
-  
+
   meniscus_av /= x_meniscuses.size();
-   
+
   //double meniscus_av = 5.95;
   return meniscus_av;
 }
@@ -4576,14 +4609,14 @@ double US_Edit::find_meniscus_interference_auto()
 
 double US_Edit::find_meniscus_auto()
 {
-  double bottom_db     = centerpiece_info[ "bottom" ].toDouble(); 
+  double bottom_db     = centerpiece_info[ "bottom" ].toDouble();
   double pathlength_db = centerpiece_info[ "pathlen" ].toDouble();
   double angle_db      = centerpiece_info[ "angle" ].toDouble();
 
   //double aprofile_volume   = 460; // Just an example - to be read from AProfile, will be global
-  
+
   double meniscus_init = sqrt( bottom_db*bottom_db - ( aprofile_volume*360/(1000*pathlength_db*angle_db*M_PI ) ) );     //Radians = Degrees * (M_PI/180.0)
-  
+
   qDebug() << "Meniscus_init: " << meniscus_init << ", " << bottom_db << ", " << pathlength_db << ", " << angle_db << ", " << M_PI;
 
   //HARD CODED [for now?]:
@@ -4591,20 +4624,20 @@ double US_Edit::find_meniscus_auto()
 
   if ( simulated_data )
     meniscus_init = 5.79;
-  
+
   double meniscus_av = 0;
 
   // Scan Data Processing...
   //int size = data.pointCount();
-  
+
   // For each scan in the last ~20% of scans:
   int start_scan = int(0.8*data.scanData.size());
   int end_scan   = data.scanData.size();
-  
-   
+
+
   QVector< double > x_maxs;
 
-  qDebug() << "Scans for meniscus: start_scan, end_scan: " << start_scan << ", " << end_scan; 
+  qDebug() << "Scans for meniscus: start_scan, end_scan: " << start_scan << ", " << end_scan;
 
   for ( int i = start_scan; i < end_scan; i++ )
     {
@@ -4622,15 +4655,15 @@ double US_Edit::find_meniscus_auto()
 
       //int indexRight  = data.xindex( range_right );
       //ALEXEY: maybe to be on safer side, take indexRight = meniscus_init  + ( aprofile_right - meniscus_init )/2.0!!!
-      int indexRight  = data.xindex( meniscus_init + ( range_right - meniscus_init )/1.5 );   
+      int indexRight  = data.xindex( meniscus_init + ( range_right - meniscus_init )/1.5 );
 
       qDebug() << "data.xindex( range_right ) = " << data.xindex( range_right );
-      qDebug() << "indexLeft = " << indexLeft << "; indexRight = " <<  indexRight; 
-	
+      qDebug() << "indexLeft = " << indexLeft << "; indexRight = " <<  indexRight;
+
       for ( int j = indexLeft; j <= indexRight; j++ )
       {
 	double y_curr = s->rvalues[ j ] * invert;
-	
+
 	if ( y_curr > y_max )
 	  {
 	    y_max = y_curr;
@@ -4640,7 +4673,7 @@ double US_Edit::find_meniscus_auto()
 	  }
       }
       //Array of maximum values indexes for the last ~20% of scans in the region [ meniscus_left -- meniscus_left + 0.1 ]
-      x_maxs.push_back( x_max ); 
+      x_maxs.push_back( x_max );
     }
 
   //Find simple average position of the meniscus
@@ -4649,9 +4682,9 @@ double US_Edit::find_meniscus_auto()
       meniscus_av += x_maxs[ i ];
       //qDebug() << "x_max: " << x_maxs[ i ] ;
     }
-  
+
   meniscus_av /= x_maxs.size();
-  
+
   return meniscus_av;
 }
 
@@ -4662,7 +4695,7 @@ int US_Edit::scan_db_auto( void )
    int  naucf        = 0;
    QStringList runIDs;
    QStringList infoDs;
-   
+
    US_Passwd   pw;
    US_DB2      db( pw.getPasswd() );
 
@@ -4692,8 +4725,8 @@ int US_Edit::scan_db_auto( void )
    query << "get_raw_desc_by_runID" << idInv_auto << filename_runID_auto;
 
    qDebug() << "IN scan_db_auto: query: " << query;
-     
-   
+
+
    db.query( query );
 
    while ( db.next() )
@@ -4727,8 +4760,8 @@ int US_Edit::scan_db_auto( void )
    // *** set key/value in the type_map for processed type to 0 && reset type_to_process ****//
    if ( runType_combined_IP_RI )
      runTypes_map[ filename_runID_auto ] = 0;
-   
-   
+
+
    return naucf;
 }
 
@@ -4906,21 +4939,21 @@ DbgLv(1) << "Ld: runID" << runID << "wdir" << workingDir;
    {
       QMessageBox::warning( this,
             tr( "No Files Found" ),
-            tr( "There were no files of the form *.auc\n"  
+            tr( "There were no files of the form *.auc\n"
                 "found in the specified directory." ) );
       return;
    }
 
    cb_triple->addItems( triples );
-   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                        SLOT  ( new_triple         ( int ) ) );
    triple_index = 0;
    data_index   = 0;
-   
+
    le_info->setText( runID );
 
    data     = allData[ 0 ];
-   dataType = QString( QChar( data.type[ 0 ] ) ) 
+   dataType = QString( QChar( data.type[ 0 ] ) )
             + QString( QChar( data.type[ 1 ] ) );
 
    if ( dataType == "IP" )
@@ -4932,13 +4965,13 @@ DbgLv(1) << "Ld: runID" << runID << "wdir" << workingDir;
       ct_gaps->setValue     ( 0.4 );
       ct_gaps->setNumButtons( 3 );
 
-      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ), 
+      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ),
                         SLOT  ( set_fringe_tolerance( double ) ) );
    }
    else
    {
       lb_gaps->setText( tr( "Threshold for Scan Gaps" ) );
-      
+
       ct_gaps->disconnect   ();
       ct_gaps->setRange     ( 10.0, 100.0 );
       ct_gaps->setSingleStep( 10.0 );
@@ -5037,7 +5070,7 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       }
 
       QStringList query;
-      query << "get_experiment_info_by_runID" << runID 
+      query << "get_experiment_info_by_runID" << runID
             << QString::number( US_Settings::us_inv_ID() );
 
       dbP->query( query );
@@ -5067,9 +5100,9 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       lb_rpms    ->setVisible( true  );
       cb_rpms    ->setVisible( true  );
       pb_plateau ->setVisible( false );
-      le_plateau ->setVisible( false ); 
-      lb_baseline->setVisible( false ); 
-      le_baseline->setVisible( false ); 
+      le_plateau ->setVisible( false );
+      lb_baseline->setVisible( false );
+      le_baseline->setVisible( false );
       lb_edtrsp  ->setVisible( true  );
       le_edtrsp  ->setVisible( true  );
       pb_reviewep->setVisible( true  );
@@ -5147,7 +5180,7 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       connect( pb_priorEdits, SIGNAL( clicked() ), SLOT( prior_equil() ) );
       plot_scan();
 
-      connect( cb_rpms,   SIGNAL( currentIndexChanged( int ) ), 
+      connect( cb_rpms,   SIGNAL( currentIndexChanged( int ) ),
                           SLOT  ( new_rpmval         ( int ) ) );
    }
 
@@ -5157,9 +5190,9 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       lb_rpms    ->setVisible( false );
       cb_rpms    ->setVisible( false );
 //      pb_plateau ->setVisible( true  );
-      le_plateau ->setVisible( true  ); 
+      le_plateau ->setVisible( true  );
       lb_baseline->setVisible( notMwl );
-      le_baseline->setVisible( notMwl ); 
+      le_baseline->setVisible( notMwl );
       lb_edtrsp  ->setVisible( false );
       le_edtrsp  ->setVisible( false );
       pb_reviewep->setVisible( false );
@@ -5443,7 +5476,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
       cb_triple->disconnect();
       cb_triple->clear();
       cb_triple->addItems( celchns );
-      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                           SLOT  ( new_triple         ( int ) ) );
       pb_nextChan->setEnabled( celchns.size() > 1 );
 
@@ -5516,26 +5549,26 @@ DbgLv(1) << "Ld: runID" << runID << "wdir" << workingDir;
    sd_knts   .clear();
    cb_triple->clear();
    files     .clear();
-   
+
    if ( triples.size() == 0 )
    {
       QMessageBox::warning( this,
             tr( "No Files Found" ),
-            tr( "There were no files of the form *.auc\n"  
+            tr( "There were no files of the form *.auc\n"
                 "found in the specified directory." ) );
       return;
    }
 
    cb_triple->addItems( triples );
-   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                        SLOT  ( new_triple         ( int ) ) );
    triple_index = 0;
    data_index   = 0;
-   
+
    le_info->setText( runID );
 
    data     = allData[ 0 ];
-   dataType = QString( QChar( data.type[ 0 ] ) ) 
+   dataType = QString( QChar( data.type[ 0 ] ) )
             + QString( QChar( data.type[ 1 ] ) );
 
    if ( dataType == "IP" )
@@ -5547,13 +5580,13 @@ DbgLv(1) << "Ld: runID" << runID << "wdir" << workingDir;
       ct_gaps->setValue     ( 0.4 );
       ct_gaps->setNumButtons( 3 );
 
-      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ), 
+      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ),
                         SLOT  ( set_fringe_tolerance( double ) ) );
    }
    else
    {
       lb_gaps->setText( tr( "Threshold for Scan Gaps" ) );
-      
+
       ct_gaps->disconnect   ();
       ct_gaps->setRange     ( 10.0, 100.0 );
       ct_gaps->setSingleStep( 10.0 );
@@ -5652,7 +5685,7 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       }
 
       QStringList query;
-      query << "get_experiment_info_by_runID" << runID 
+      query << "get_experiment_info_by_runID" << runID
             << QString::number( US_Settings::us_inv_ID() );
 
       dbP->query( query );
@@ -5682,9 +5715,9 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       lb_rpms    ->setVisible( true  );
       cb_rpms    ->setVisible( true  );
       pb_plateau ->setVisible( false );
-      le_plateau ->setVisible( false ); 
-      lb_baseline->setVisible( false ); 
-      le_baseline->setVisible( false ); 
+      le_plateau ->setVisible( false );
+      lb_baseline->setVisible( false );
+      le_baseline->setVisible( false );
       lb_edtrsp  ->setVisible( true  );
       le_edtrsp  ->setVisible( true  );
       pb_reviewep->setVisible( true  );
@@ -5762,7 +5795,7 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       connect( pb_priorEdits, SIGNAL( clicked() ), SLOT( prior_equil() ) );
       plot_scan();
 
-      connect( cb_rpms,   SIGNAL( currentIndexChanged( int ) ), 
+      connect( cb_rpms,   SIGNAL( currentIndexChanged( int ) ),
                           SLOT  ( new_rpmval         ( int ) ) );
    }
 
@@ -5772,9 +5805,9 @@ DbgLv(1) << " celchns    size" << celchns.size() << ncelchn;
       lb_rpms    ->setVisible( false );
       cb_rpms    ->setVisible( false );
 //      pb_plateau ->setVisible( true  );
-      le_plateau ->setVisible( true  ); 
+      le_plateau ->setVisible( true  );
       lb_baseline->setVisible( notMwl );
-      le_baseline->setVisible( notMwl ); 
+      le_baseline->setVisible( notMwl );
       lb_edtrsp  ->setVisible( false );
       le_edtrsp  ->setVisible( false );
       pb_reviewep->setVisible( false );
@@ -5995,7 +6028,7 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
       cb_triple->disconnect();
       cb_triple->clear();
       cb_triple->addItems( celchns );
-      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                           SLOT  ( new_triple         ( int ) ) );
       pb_nextChan->setEnabled( celchns.size() > 1 );
 
@@ -6150,7 +6183,7 @@ void US_Edit::set_data_over_lamda() {
 void US_Edit::set_pbColors( QPushButton* pb )
 {
    QPalette p = US_GuiSettings::pushbColor();
-   
+
    pb_meniscus ->setPalette( p );
    pb_airGap   ->setPalette( p );
 //   pb_dataRange->setPalette( p );
@@ -6183,7 +6216,7 @@ void US_Edit::plot_current( int index )
 
    QString     desc    = data.description;
 
-   dataType = QString( QChar( data.type[ 0 ] ) ) 
+   dataType = QString( QChar( data.type[ 0 ] ) )
             + QString( QChar( data.type[ 1 ] ) );
 
    if ( dataType == "IP" )
@@ -6225,7 +6258,7 @@ void US_Edit::plot_current( int index )
       title = "Fluorescence Intensity Data\n" + title23;
       data_plot->setAxisTitle( QwtPlot::yLeft, tr( "Fluorescence Intensity " ) );
    }
-   else 
+   else
       title = "File type not recognized";
 
    data_plot->setTitle( title );
@@ -6252,7 +6285,7 @@ void US_Edit::plot_current( int index )
 void US_Edit::replot( void )
 {
   qDebug() << "In replot: step -- " << step;
-  
+
    switch( step )
    {
       case FINISHED:
@@ -6303,9 +6336,9 @@ void US_Edit::mouse( const QwtDoublePoint& p )
             data_plot->replot();
 
             pb_meniscus->setIcon( check );
-         
+
 //            pb_dataRange->setEnabled( true );
-        
+
             next_step();
             break;
          }
@@ -6322,7 +6355,7 @@ void US_Edit::mouse( const QwtDoublePoint& p )
             if ( qAbs( p.x() - meniscus_left ) < 0.005 ) return;
 
             double meniscus_right = p.x();
-            
+
             // Swap values if necessary.  Use a macro in us_math.h
             if ( meniscus_right < meniscus_left )
                swap_double( meniscus_left, meniscus_right );
@@ -6369,7 +6402,7 @@ void US_Edit::mouse( const QwtDoublePoint& p )
             marker = new QwtPlotMarker;
             QBrush brush( Qt::white );
             QPen   pen  ( brush, 2.0 );
-            QwtSymbol * symb = new QwtSymbol( QwtSymbol::Cross, 
+            QwtSymbol * symb = new QwtSymbol( QwtSymbol::Cross,
                                               brush, pen, QSize ( 8, 8 ) );
             marker->setValue ( meniscus, maximum );
             marker->setSymbol( symb );
@@ -6379,7 +6412,7 @@ void US_Edit::mouse( const QwtDoublePoint& p )
          data_plot->replot();
 
          pb_meniscus->setIcon( check );
-         
+
          if ( dataType == "IP" )
          {
             pb_airGap->setEnabled( true );
@@ -6387,7 +6420,7 @@ void US_Edit::mouse( const QwtDoublePoint& p )
          }
          else
 //            pb_dataRange->setEnabled( true );
-        
+
          next_step();
          break;
 
@@ -6404,7 +6437,7 @@ void US_Edit::mouse( const QwtDoublePoint& p )
 
             airGap_right = p.x();
 
-            if ( airGap_right < airGap_left ) 
+            if ( airGap_right < airGap_left )
                swap_double( airGap_left, airGap_right );
 
             US_DataIO::EditValues  edits;
@@ -6412,7 +6445,7 @@ void US_Edit::mouse( const QwtDoublePoint& p )
             edits.airGapRight = airGap_right;
 
             QList< int > excludes;
-            
+
             for ( int i = 0; i < data.scanData.size(); i++ )
                if ( ! includes.contains( i ) ) edits.excludes << i;
 
@@ -6425,7 +6458,7 @@ DbgLv(1) << "AGap: L R" << airGap_left << airGap_right << " AdjIntf";
 
             // Display the data
             QString wkstr;
-            le_airGap->setText( wkstr.sprintf( "%.3f - %.3f", 
+            le_airGap->setText( wkstr.sprintf( "%.3f - %.3f",
                      airGap_left, airGap_right ) );
 
             step          = RANGE;
@@ -6436,7 +6469,7 @@ DbgLv(1) << "AGap:  plot_range()";
             plot_range();
 
             qApp->processEvents();
-            
+
             pb_airGap   ->setIcon( check );
             pb_dataRange->setEnabled( true );
 
@@ -6446,10 +6479,10 @@ DbgLv(1) << "AGap:  plot_range()";
          break;
 
 
-	 
+
       case RANGE:
 	qDebug() << "range_left, range_right -- "
-		 << range_left <<  range_right; 
+		 << range_left <<  range_right;
          if ( range_left == 0.0 )
          {
             if ( v_line != NULL )
@@ -6528,16 +6561,16 @@ DbgLv(1) << "AGap:  plot_range()";
                edits.gapTolerance = ct_gaps->value();
 
                QList< int > excludes;
-               
+
                for ( int i = 0; i < data.scanData.size(); i++ )
                   if ( ! includes.contains( i ) ) edits.excludes << i;
-            
+
                US_DataIO::calc_integral( data, edits );
             }
-            
+
             // Display the data
             QString wkstr;
-//            le_dataRange->setText( wkstr.sprintf( "%.3f - %.3f", 
+//            le_dataRange->setText( wkstr.sprintf( "%.3f - %.3f",
 //                     range_left, range_right ) );
             le_dataStart->setText( QString::number( range_left,  'f', 8 ) );
             le_dataEnd  ->setText( QString::number( range_right, 'f', 8 ) );
@@ -6552,7 +6585,7 @@ DbgLv(1) << "AGap:  plot_range()";
 
             // Skip the gap check for interference data
             if ( dataType != "IP" ) gap_check();
-            
+
 //            pb_dataRange->setIcon( check );
 //            pb_plateau  ->setEnabled( true );
             pb_dataEnd  ->setIcon( check );
@@ -6653,7 +6686,7 @@ DbgLv(1) << "AGap:  plot_range()";
 
 	       if ( us_edit_auto_mode_manual || us_edit_auto_mode_manual_bll )
 		 pb_pass->setEnabled( true );
-	       
+
                ck_writemwl->setEnabled( true );
                changes_made = all_edits;
             }
@@ -6685,7 +6718,7 @@ DbgLv(1) << "AGap:  plot_range()";
 
 	 if ( us_edit_auto_mode_manual || us_edit_auto_mode_manual_bll )
 	   pb_pass->setEnabled( true );
-	 
+
          ck_writemwl->setEnabled( isMwl );
          changes_made = true;
          next_step();
@@ -6695,7 +6728,7 @@ DbgLv(1) << "AGap:  plot_range()";
          {
             // Use the last scan
             US_DataIO::Scan* scan = &data.scanData.last();
-            
+
             int start = data.xindex( range_left );
             int end   = data.xindex( range_right );
             int pt    = data.xindex( p.x() );
@@ -6716,7 +6749,7 @@ DbgLv(1) << "AGap:  plot_range()";
 
             double bl = sum / 11.0;
             baseline  = p.x();
-            plateau   = ( plateau > 0.0 ) ? plateau 
+            plateau   = ( plateau > 0.0 ) ? plateau
                                           : ( range_right - _PLATEAU_OFFSET_ );
 
             QString wkstr;
@@ -6731,7 +6764,7 @@ DbgLv(1) << "BL: AA : baseline bl" << baseline << bl;
 
 	 if ( us_edit_auto_mode_manual || us_edit_auto_mode_manual_bll )
 	   pb_pass->setEnabled( true );
-	 
+
          ck_writemwl   ->setEnabled( isMwl );
          changes_made = true;
          next_step();
@@ -6754,22 +6787,22 @@ DbgLv(1) << "BL: AA : baseline bl" << baseline << bl;
 	     qDebug() << "fixedPoint -- "
 		      <<  fixedPoint.x()
 		      <<  fixedPoint.y();
-	   
+
 	     pick->setStateMachine(new QwtPickerTrackerMachine());
 	     connect(pick, SIGNAL(moved(const QPointF&)), this, SLOT(onMouseMoved(const QPointF&)));
-	     
+
 	     break;
 	   }
 	 else
 	   {
-	     disconnect(pick, SIGNAL(moved(const QPointF&)), 0, 0); 
+	     disconnect(pick, SIGNAL(moved(const QPointF&)), 0, 0);
 	     if ( line_to_mouse != NULL )
 	       {
 		 line_to_mouse->detach();
 		 delete line_to_mouse;
 		 line_to_mouse = NULL;
 	       }
-	     
+
 	     bl_corr_right_x = radius_indexed( p.x() );
 	     bl_corr_right_y = p.y();
 
@@ -6777,7 +6810,7 @@ DbgLv(1) << "BL: AA : baseline bl" << baseline << bl;
 		      << bl_corr_left_x << bl_corr_right_x
 		      << bl_corr_left_y << bl_corr_right_y;
 	   }
-	 
+
 	 {
 	   bl_corr_slope = (bl_corr_right_y - bl_corr_left_y) / ( bl_corr_right_x - bl_corr_left_x);
 	   double x_intercept = bl_corr_left_x - bl_corr_left_y / bl_corr_slope;
@@ -6786,16 +6819,16 @@ DbgLv(1) << "BL: AA : baseline bl" << baseline << bl;
 	   //replot with baseline corrections
 	   plot_range_and_blc();
 
-	   //enable accept 
+	   //enable accept
 	   if ( us_edit_auto_mode_manual || us_edit_auto_mode_manual_bll )
 	     pb_pass->setEnabled( true );
-	   
+
 	   //update gui fields
 	   le_bll_slope     ->setText( QString::number( bl_corr_slope, 'f', 8 ) );
 	   le_bll_intercept ->setText( QString::number( bl_corr_yintercept, 'f', 8 ) );
 	 }
 	 break;
-	 
+
    default:
      break;
    }
@@ -6810,7 +6843,7 @@ void US_Edit::onMouseMoved(const QPointF& mousePos)
       delete line_to_mouse;
       line_to_mouse = NULL;
     }
-  
+
   #if QT_VERSION < 0x050000
    QwtScaleDiv* y_axis = data_plot->axisScaleDiv( QwtPlot::yLeft );
 #else
@@ -6863,8 +6896,8 @@ void US_Edit::draw_vline( double radius )
 void US_Edit::next_step( void )
 {
    QPushButton* pb;
-   
-   if      ( meniscus == 0.0 ) 
+
+   if      ( meniscus == 0.0 )
    {
       step = MENISCUS;
       pb   = pb_meniscus;
@@ -6885,7 +6918,7 @@ void US_Edit::next_step( void )
    }
 
 #if 0
-   else if ( plateau == 0.0 ) 
+   else if ( plateau == 0.0 )
    {
       step = PLATEAU;
       pb   = pb_plateau;
@@ -6900,9 +6933,9 @@ void US_Edit::next_step( void )
       double sum = 0.0;
       int    pt  = data.xindex( range_left );
       baseline   = data.xvalues[ pt + 5 ];
-      plateau    = ( plateau > 0.0 ) ? plateau 
+      plateau    = ( plateau > 0.0 ) ? plateau
                                      : ( range_right - _PLATEAU_OFFSET_ );
-      
+
       if ( !isMwl )
       {
          // Average the value for +/- 5 points
@@ -6916,7 +6949,7 @@ void US_Edit::next_step( void )
 	 DbgLv(1) << "BL: BB : baseline bl" << baseline << bl;
 
 	 baseline_od = bl;
- 
+
 	 qDebug() << "SETTING Baseline, Plateau : baseline bl" << baseline << bl;
          le_plateau ->setText( QString::number( plateau, 'f', 8 ) );
       }
@@ -6932,7 +6965,7 @@ void US_Edit::next_step( void )
 	      baseline_od = 0;
 	    }
 	}
-      
+
    }
 
    set_pbColors( pb );
@@ -6954,7 +6987,7 @@ void US_Edit::set_meniscus( void )
        le_bll_intercept->setText( "" );
        pb_baseline_correct ->setEnabled( false );
      }
-   
+
    meniscus      = 0.0;
    meniscus_left = 0.0;
    airGap_left   = 0.0;
@@ -6969,9 +7002,9 @@ void US_Edit::set_meniscus( void )
    bl_corr_slope  = 0.0;
    plateau       = 0.0;
    baseline      = 0.0;
-   
+
    step          = MENISCUS;
-   
+
    set_pbColors( pb_meniscus );
    pb_meniscus->setIcon( QIcon() );
 
@@ -6989,7 +7022,7 @@ DbgLv(1) << "set_meniscus -- changes_made" << changes_made;
 
    // Clear any existing marker
    data_plot->detachItems( QwtPlotItem::Rtti_PlotMarker );
-            
+
    // Reset data and plot
    undo();
 
@@ -7009,7 +7042,7 @@ void US_Edit::set_airGap( void )
    le_dataEnd  ->setText( "" );
    le_plateau  ->setText( "" );
    le_baseline ->setText( "" );
-   
+
    airGap_left   = 0.0;
    airGap_right  = 9.0;
    range_left    = 0.0;
@@ -7022,7 +7055,7 @@ void US_Edit::set_airGap( void )
    bl_corr_slope  = 0.0;
    plateau       = 0.0;
    baseline      = 0.0;
-   
+
    step        = AIRGAP;
    set_pbColors( pb_airGap );
    pb_airGap   ->setIcon( QIcon() );
@@ -7050,7 +7083,7 @@ void US_Edit::set_linear_baseline_corr( void )
   bl_corr_right_x = 9.0;
   bl_corr_left_y  = 0.0;
   bl_corr_right_y = 0.0;
-  
+
   step        = BASELINE_LINEAR_CORR;
 
   if ( ! expIsEquil )
@@ -7076,7 +7109,7 @@ void US_Edit::set_dataRange( void )
    le_bll_slope->setText( "" );
    le_bll_intercept->setText( "" );
    pb_baseline_correct->setEnabled( false );
-   
+
    range_left    = 0.0;
    range_right   = 9.0;
    bl_corr_left_x  = 0.0;
@@ -7087,7 +7120,7 @@ void US_Edit::set_dataRange( void )
    bl_corr_slope  = 0.0;
    plateau       = 0.0;
    baseline      = 0.0;
-   
+
    step        = RANGE;
 
    pb_report   ->setEnabled( all_edits );
@@ -7115,10 +7148,10 @@ void US_Edit::set_plateau( void )
 {
    le_plateau  ->setText( "" );
    le_baseline ->setText( "" );
-   
+
    plateau       = 0.0;
    baseline      = 0.0;
-   
+
    step = PLATEAU;
    set_pbColors( pb_plateau );
 
@@ -7153,10 +7186,10 @@ DbgLv(1) << " 1)gap_fringe" << gap_fringe;
    edits.airGapRight = airGap_right;
 
    QList< int > excludes;
-            
+
    for ( int i = 0; i < data.scanData.size(); i++ )
       if ( ! includes.contains( i ) ) edits.excludes << i;
-         
+
    US_DataIO::adjust_interference( data, edits );
 
    edits.rangeLeft    = range_left;
@@ -7186,7 +7219,7 @@ DbgLv(1) << " PlAll:  nmcols" << nmcols;
    if ( plot->btnZoom->isChecked() )
       plot->btnZoom->setChecked( false );
 
-   data_plot->detachItems( QwtPlotItem::Rtti_PlotCurve ); 
+   data_plot->detachItems( QwtPlotItem::Rtti_PlotCurve );
    v_line = NULL;
 
    int size = data.pointCount();
@@ -7204,7 +7237,7 @@ DbgLv(1) << " PlAll:  nmcols" << nmcols;
    for ( int i = 0; i < data.scanData.size(); i++ )
    {
       if ( ! includes.contains( i ) ) continue;
-      
+
       US_DataIO::Scan*  s = &data.scanData[ i ];
 
       for ( int j = 0; j < size; j++ )
@@ -7286,9 +7319,9 @@ DbgLv(1) << "plot_range(): ccx wvx indext" << ccx << wvx << indext;
    for ( int i = 0; i < data.scanData.size(); i++ )
    {
       if ( ! includes.contains( i ) ) continue;
-      
+
       US_DataIO::Scan*  s = &data.scanData[ i ];
-      
+
       int indexLeft  = data.xindex( range_left );
       int indexRight = data.xindex( range_right );
       double menp    = 0.0;
@@ -7334,7 +7367,7 @@ DbgLv(1) << "plot_range(): ccx wvx indext" << ccx << wvx << indext;
          r[ 4 ]     = r[ 0 ];
          v[ 4 ]     = v[ 0 ];
 
-         QwtPlotCurve* c = us_curve( data_plot, tr( "Meniscus at" ) + 
+         QwtPlotCurve* c = us_curve( data_plot, tr( "Meniscus at" ) +
                   QString::number( tScan ) );
          c->setBrush( QBrush( Qt::cyan ) );
          c->setPen(   QPen(   Qt::cyan ) );
@@ -7342,15 +7375,15 @@ DbgLv(1) << "plot_range(): ccx wvx indext" << ccx << wvx << indext;
          minR       = qMin( minR, r[ 0 ] );
          minV       = qMin( minV, v[ 0 ] );
       }
-      
+
       int     count  = 0;
-      
+
       for ( int j = indexLeft; j <= indexRight; j++ )
       {
          r[ count ] = data.xvalues[ j ];
          //v[ count ] = s  ->rvalues[ j ] * invert;
-	 v[ count ] = s  ->rvalues[ j ] * invert - ( r[ count ]*bl_corr_slope + bl_corr_yintercept); 
-	 
+	 v[ count ] = s  ->rvalues[ j ] * invert - ( r[ count ]*bl_corr_slope + bl_corr_yintercept);
+
          maxR       = qMax( maxR, r[ count ] );
          minR       = qMin( minR, r[ count ] );
          maxV       = qMax( maxV, v[ count ] );
@@ -7383,7 +7416,7 @@ DbgLv(2) << " PlRng:      i" << i << "pen_plot" << pen_plot;
    // Reset colors
    focus( (int)ct_from->value(), (int)ct_to->value() );
    data_plot->replot();
-   
+
 
 }
 
@@ -7428,9 +7461,9 @@ DbgLv(1) << "plot_range(): ccx wvx indext" << ccx << wvx << indext;
    for ( int i = 0; i < data.scanData.size(); i++ )
    {
       if ( ! includes.contains( i ) ) continue;
-      
+
       US_DataIO::Scan*  s = &data.scanData[ i ];
-      
+
       int indexLeft  = data.xindex( range_left );
       int indexRight = data.xindex( range_right );
       double menp    = 0.0;
@@ -7476,7 +7509,7 @@ DbgLv(1) << "plot_range(): ccx wvx indext" << ccx << wvx << indext;
          r[ 4 ]     = r[ 0 ];
          v[ 4 ]     = v[ 0 ];
 
-         QwtPlotCurve* c = us_curve( data_plot, tr( "Meniscus at" ) + 
+         QwtPlotCurve* c = us_curve( data_plot, tr( "Meniscus at" ) +
                   QString::number( tScan ) );
          c->setBrush( QBrush( Qt::cyan ) );
          c->setPen(   QPen(   Qt::cyan ) );
@@ -7484,9 +7517,9 @@ DbgLv(1) << "plot_range(): ccx wvx indext" << ccx << wvx << indext;
          minR       = qMin( minR, r[ 0 ] );
          minV       = qMin( minV, v[ 0 ] );
       }
-      
+
       int     count  = 0;
-      
+
       for ( int j = indexLeft; j <= indexRight; j++ )
       {
          r[ count ] = data.xvalues[ j ];
@@ -7534,7 +7567,7 @@ void US_Edit::plot_last( void )
 
    data_plot->detachItems( QwtPlotItem::Rtti_PlotCurve );
    v_line = NULL;
-   //grid = us_grid( data_plot ); 
+   //grid = us_grid( data_plot );
 
    double maxR = -1.0e99;
    double minR =  1.0e99;
@@ -7543,17 +7576,17 @@ void US_Edit::plot_last( void )
 
    // Plot only the last scan
    US_DataIO::Scan*  s = &data.scanData[ includes.last() ];;
-   
+
    int indexLeft  = data.xindex( range_left );
    int indexRight = data.xindex( range_right );
-   
+
    int     count  = 0;
    uint    size   = s->rvalues.size();
    QVector< double > rvec( size );
    QVector< double > vvec( size );
    double* r      = rvec.data();
    double* v      = vvec.data();
-   
+
    for ( int j = indexLeft; j <= indexRight; j++ )
    {
       r[ count ] = data.xvalues[ j ];
@@ -7681,7 +7714,7 @@ void US_Edit::plot_mwl( void )
 		<< data_index;
 
        triple_plot_first_time[ triple_index ] = 1;
-    
+
      }
    /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -7695,7 +7728,7 @@ DbgLv(1) << "PlMwl:    expc_wvlns size" << expc_wvlns.size();
       data                = *outData[ data_index ];
 
       qDebug() << "IN_edit_1";
-      
+
       recvalu             = expi_wvlns.at( recndx );
 
       qDebug() << "IN_edit_2";
@@ -7705,11 +7738,11 @@ DbgLv(1) << "PlMwl:    expc_wvlns size" << expc_wvlns.size();
 QString dcell=QString::number(data.cell);
 
  qDebug() << "IN_edit_4";
- 
+
 QString dchan=QString(QChar(data.channel));
 
  qDebug() << "IN_edit_5";
- 
+
 QString dwavl=QString::number(data.scanData[0].wavelength);
 DbgLv(1) << "PlMwl:     c triple" << scell << schan << svalu
  << "d triple" << dcell << dchan << dwavl;
@@ -7729,7 +7762,7 @@ DbgLv(1) << "PlMwl: ccx index rtype rval" << ccx << index << rectype << recvalu;
    // Read the data description
    QString     desc    = data.description;
 
-   dataType            = QString( QChar( data.type[ 0 ] ) ) 
+   dataType            = QString( QChar( data.type[ 0 ] ) )
                        + QString( QChar( data.type[ 1 ] ) );
 
    le_info->setText( runID + "  (" + desc + ")" );
@@ -7772,7 +7805,7 @@ DbgLv(1) << "PlMwl:  title" << title;
    data_plot->setTitle    ( title );
 
 
-   data_plot->detachItems ( QwtPlotItem::Rtti_PlotCurve ); 
+   data_plot->detachItems ( QwtPlotItem::Rtti_PlotCurve );
    v_line = NULL;
 
    int     nscan  = data.scanData.size();
@@ -7915,7 +7948,7 @@ void US_Edit::focus_from( double scan )
       ct_to->disconnect();
       ct_to->setValue( scan );
       to = from;
-      
+
       connect( ct_to, SIGNAL( valueChanged ( double ) ),
                       SLOT  ( focus_to     ( double ) ) );
    }
@@ -7934,7 +7967,7 @@ void US_Edit::focus_to( double scan )
       ct_from->disconnect();
       ct_from->setValue( scan );
       from = to;
-      
+
       connect( ct_from, SIGNAL( valueChanged ( double ) ),
                         SLOT  ( focus_from   ( double ) ) );
    }
@@ -7978,7 +8011,7 @@ DbgLv(1) << "ED:scol: nmcols" << nmcols << mcolors.size();
    // Get pointers to curves
    QwtPlotItemList        list = data_plot->itemList();
    QList< QwtPlotCurve* > curves;
-   
+
    for ( int i = 0; i < list.size(); i++ )
    {
       if ( list[ i ]->title().text().contains( "Raw" ) )
@@ -8051,12 +8084,12 @@ void US_Edit::exclude_all_but_last( void )
   int scanEnd   = data.scanData.size() - 1;
 
   qDebug() << "includes before: " << includes;
-  
+
   for ( int i = scanEnd; i >= scanStart; i-- )
     includes.removeAt( i - 1 );
 
   qDebug() << "includes after " << includes;
-  
+
   replot();
   reset_excludes();
 }
@@ -8079,14 +8112,14 @@ void US_Edit::exclusion( void )
 {
    reset_excludes();
    US_ExcludeProfile* exclude = new US_ExcludeProfile( includes );
- 
-   connect( exclude, SIGNAL( update_exclude_profile( QList< int > ) ), 
+
+   connect( exclude, SIGNAL( update_exclude_profile( QList< int > ) ),
             this   , SLOT  ( update_excludes       ( QList< int > ) ) );
-   
-   connect( exclude, SIGNAL( cancel_exclude_profile( void ) ), 
+
+   connect( exclude, SIGNAL( cancel_exclude_profile( void ) ),
             this   , SLOT  ( cancel_excludes       ( void ) ) );
 
-   connect( exclude, SIGNAL( finish_exclude_profile( QList< int > ) ), 
+   connect( exclude, SIGNAL( finish_exclude_profile( QList< int > ) ),
             this   , SLOT  ( finish_excludes       ( QList< int > ) ) );
 
    exclude->exec();
@@ -8125,7 +8158,7 @@ void US_Edit::edit_scan( void )
    int index1 = (int)ct_from->value();
    int scan  = includes[ index1 - 1 ];
 
-   US_EditScan* dialog = new US_EditScan( data.scanData[ scan ], data.xvalues, 
+   US_EditScan* dialog = new US_EditScan( data.scanData[ scan ], data.xvalues,
          invert, range_left, range_right );
    connect( dialog, SIGNAL( scan_updated( QList< QPointF > ) ),
                     SLOT  ( update_scan ( QList< QPointF > ) ) );
@@ -8204,7 +8237,7 @@ void US_Edit::update_scan( QList< QPointF > changes )
       }
    }
 
-   if ( found ) 
+   if ( found )
    {
       // Update the curve
       c->setSamples( r, v, count );
@@ -8245,7 +8278,7 @@ void US_Edit::remove_spikes( void )
    double smoothed_value;
 
    // For each scan
-   for ( int i = 0; i < data.scanData.size(); i++ ) 
+   for ( int i = 0; i < data.scanData.size(); i++ )
    {
       US_DataIO::Scan* s = &data.scanData [ i ];
 
@@ -8254,12 +8287,12 @@ void US_Edit::remove_spikes( void )
 
       for ( int j = start; j < end; j++ )
       {
-         if ( US_DataIO::spike_check( *s, data.xvalues, j, start, end, 
+         if ( US_DataIO::spike_check( *s, data.xvalues, j, start, end,
                                       &smoothed_value ) )
          {
             s->rvalues[ j ]     = smoothed_value;
 
-            // If previous consecututive points are interpolated, then 
+            // If previous consecututive points are interpolated, then
             // redo them
             int           index = j - 1;
             unsigned char c     = s->interpolated[ index / 8 ];
@@ -8282,7 +8315,7 @@ void US_Edit::remove_spikes( void )
    pb_write ->setEnabled( true );
    replot();
 
-   
+
 }
 
 
@@ -8295,30 +8328,30 @@ void US_Edit::remove_spikes_auto( void )
     {
       airGap_left   = editProfile[ cb_triple->currentText() ][7].toDouble();
       airGap_right  = editProfile[ cb_triple->currentText() ][8].toDouble();
-      
+
       US_DataIO::EditValues  edits;
       edits.airGapLeft  = airGap_left;
       edits.airGapRight = airGap_right;
-      
+
       QList< int > excludes;
-      
+
       for ( int i = 0; i < data.scanData.size(); i++ )
 	if ( ! includes.contains( i ) ) edits.excludes << i;
-      
+
       US_DataIO::adjust_interference( data, edits );
-      
+
       edits.rangeLeft    = range_left;
       edits.rangeRight   = range_right;
       edits.gapTolerance = ct_gaps->value();
-      
+
       US_DataIO::calc_integral( data, edits );
     }
   /**************************************************************************************/
-  
+
   double smoothed_value;
 
    // For each scan
-   for ( int i = 0; i < data.scanData.size(); i++ ) 
+   for ( int i = 0; i < data.scanData.size(); i++ )
    {
       US_DataIO::Scan* s = &data.scanData [ i ];
 
@@ -8327,12 +8360,12 @@ void US_Edit::remove_spikes_auto( void )
 
       for ( int j = start; j < end; j++ )
       {
-         if ( US_DataIO::spike_check( *s, data.xvalues, j, start, end, 
+         if ( US_DataIO::spike_check( *s, data.xvalues, j, start, end,
                                       &smoothed_value ) )
          {
             s->rvalues[ j ]     = smoothed_value;
 
-            // If previous consecututive points are interpolated, then 
+            // If previous consecututive points are interpolated, then
             // redo them
             int           index = j - 1;
             unsigned char c     = s->interpolated[ index / 8 ];
@@ -8351,20 +8384,20 @@ void US_Edit::remove_spikes_auto( void )
    }
 
    pb_spikes->setIcon   ( check );
-   
+
    // // ALEXEY: resize up to (1) meniscus; (2) left_range; (3) right_range; (4) plateau; (5) baseline; (6) baseline_od
    // for (int i=0; i < editProfile[ cb_triple->currentText() ].count(); i++)
    //   {
    //     if (i > 5)
    // 	 editProfile[ cb_triple->currentText() ].removeAt(i);
    //   }
-   
+
    // editProfile[ cb_triple->currentText() ] << QString("spike_true");
 
    editProfile[ cb_triple->currentText() ][6] = QString("spike_true");
 
    qDebug() << cb_triple->currentText()  << ", " << editProfile[ cb_triple->currentText() ];
-      
+
    pb_spikes->setEnabled( false );
    //pb_write ->setEnabled( true );
 
@@ -8389,18 +8422,18 @@ void US_Edit::remove_spikes_auto( void )
 	 {
 	   airGap_left   = editProfile[ cb_triple->currentText() ][7].toDouble();
 	   airGap_right  = editProfile[ cb_triple->currentText() ][8].toDouble();
-	   
+
 	   QString wkstr;
-	   le_airGap->setText( wkstr.sprintf( "%.3f - %.3f", 
+	   le_airGap->setText( wkstr.sprintf( "%.3f - %.3f",
 					      airGap_left, airGap_right ) );
 	 }
 
-       if ( isMwl ) 
+       if ( isMwl )
 	 le_baseline ->setText( QString::number( baseline,     'f', 3 ) );
        else
 	 {
 	   QString str;
-	   le_baseline->setText( str.sprintf( "%.3f (%.3e)", baseline, baseline_od ) );   
+	   le_baseline->setText( str.sprintf( "%.3f (%.3e)", baseline, baseline_od ) );
 	 }
 
        if ( autoflow_expType == "ABDE" )
@@ -8431,7 +8464,7 @@ void US_Edit::undo_auto( void )
    {
      airGap_left   = editProfile[ cb_triple->currentText() ][7].toDouble();
      airGap_right  = editProfile[ cb_triple->currentText() ][8].toDouble();
-     
+
       US_DataIO::EditValues edits;
       edits.airGapLeft  = airGap_left;
       edits.airGapRight = airGap_right;
@@ -8439,7 +8472,7 @@ void US_Edit::undo_auto( void )
       edits.rangeLeft    = range_left;
       edits.rangeRight   = range_right;
       edits.gapTolerance = ct_gaps->value();
-      
+
       for ( int i = 0; i < data.scanData.size(); i++ )
          if ( ! includes.contains( i ) ) edits.excludes << i;
 
@@ -8464,24 +8497,24 @@ void US_Edit::undo_auto( void )
        le_dataEnd  ->setText( QString::number( range_right, 'f', 3 ) );
        le_plateau  ->setText( QString::number( plateau,     'f', 3 ) );
 
-       
+
        if ( dataType == "IP" )
 	 {
 	   airGap_left   = editProfile[ cb_triple->currentText() ][7].toDouble();
 	   airGap_right  = editProfile[ cb_triple->currentText() ][8].toDouble();
-	   
+
 	   QString wkstr;
-	   le_airGap->setText( wkstr.sprintf( "%.3f - %.3f", 
+	   le_airGap->setText( wkstr.sprintf( "%.3f - %.3f",
 					      airGap_left, airGap_right ) );
 	 }
-       
-       
-       if ( isMwl ) 
+
+
+       if ( isMwl )
 	 le_baseline ->setText( QString::number( baseline,     'f', 3 ) );
        else
 	 {
 	   QString str;
-	   le_baseline->setText( str.sprintf( "%.3f (%.3e)", baseline, baseline_od ) );   
+	   le_baseline->setText( str.sprintf( "%.3f (%.3e)", baseline, baseline_od ) );
 	 }
 
        if ( autoflow_expType == "ABDE" )
@@ -8489,8 +8522,8 @@ void US_Edit::undo_auto( void )
        else
 	 plot_range();
      }
-   
-   /*      
+
+   /*
    // Reset buttons and structures
    pb_residuals->setEnabled( false );
 
@@ -8506,23 +8539,23 @@ void US_Edit::undo_auto( void )
    }
 
    */
-   
+
    spikes      = false;
    noise_order = 0;
 
    if ( all_loaded )
      {
-       // // ALEXEY: resize up to (1) meniscus; (2) left_range; (3) right_range; (4) plateau; (5) baseline; (6) baseline_od 
+       // // ALEXEY: resize up to (1) meniscus; (2) left_range; (3) right_range; (4) plateau; (5) baseline; (6) baseline_od
        // for (int i=0; i < editProfile[ cb_triple->currentText() ].count(); i++)
        // 	 {
        // 	   if (i > 5)
        // 	     editProfile[ cb_triple->currentText() ].removeAt(i);
        // 	 }
-       
+
        // editProfile[ cb_triple->currentText() ] << QString("spike_false");
 
        editProfile[ cb_triple->currentText() ][6] = QString("spike_false");
-       
+
        qDebug() << cb_triple->currentText()  << ", " << editProfile[ cb_triple->currentText() ];
      }
 
@@ -8536,7 +8569,7 @@ void US_Edit::undo_auto( void )
 
    if (us_edit_auto_mode )
      pick-> disconnect();
-       
+
 }
 
 
@@ -8557,7 +8590,7 @@ void US_Edit::undo( void )
       edits.rangeLeft    = range_left;
       edits.rangeRight   = range_right;
       edits.gapTolerance = ct_gaps->value();
-      
+
       for ( int i = 0; i < data.scanData.size(); i++ )
          if ( ! includes.contains( i ) ) edits.excludes << i;
 
@@ -8597,7 +8630,7 @@ void US_Edit::undo( void )
 void US_Edit::noise( void )
 {
    residuals.clear();
-   US_RiNoise* dialog = new US_RiNoise( data, includes,  
+   US_RiNoise* dialog = new US_RiNoise( data, includes,
          range_left, range_right, dataType, noise_order, residuals );
    int code = dialog->exec();
    qApp->processEvents();
@@ -8631,7 +8664,7 @@ void US_Edit::subtract_residuals( void )
 void US_Edit::new_triple_auto( int index )
 {
   triple_index    = index;
-  
+
   qDebug() << "NEW_TRIPLE_AUTO: triple_index: " << triple_index;
 
   QString triple_name = cb_triple->itemText( triple_index );
@@ -8641,7 +8674,7 @@ void US_Edit::new_triple_auto( int index )
   qDebug() << "Triple_name, cb_triple->currentText() -- "
 	   << triple_name
 	   << cb_triple->currentText();
-  
+
   // Remove Spike: Icon/Enable
   if ( editProfile[ cb_triple->currentText() ].count() > 6 )
     {
@@ -8650,7 +8683,7 @@ void US_Edit::new_triple_auto( int index )
 	  pb_spikes->setIcon( check );
 	  pb_spikes->setEnabled( false );
 	  pb_undo  ->setEnabled( true );
-	  
+
 	}
       else if (editProfile[ cb_triple->currentText() ][6] == "spike_false")
 	{
@@ -8665,7 +8698,7 @@ void US_Edit::new_triple_auto( int index )
       pb_spikes->setEnabled( true );
       pb_undo  ->setEnabled( false );
     }
-  
+
       //Next/Proir triples
   if ( triple_index == 0 )
     pb_priorChan->setEnabled( false );
@@ -8676,8 +8709,8 @@ void US_Edit::new_triple_auto( int index )
     pb_nextChan->setEnabled( false );
   else
     pb_nextChan->setEnabled( true );
-      
-  
+
+
    double gap_val  = ct_gaps->value();
 DbgLv(1) << "EDT:NewTr: tripindex" << triple_index << "chgs" << changes_made << "gap_val" << gap_val;
 
@@ -8687,7 +8720,7 @@ DbgLv(1) << "EDT:NewTr: tripindex" << triple_index << "chgs" << changes_made << 
       QMessageBox mb;
       mb.setIcon( QMessageBox::Question );
       mb.setText( tr( "Ignore Edits?" ) );
-      mb.setInformativeText( 
+      mb.setInformativeText(
             tr( "Edits have been made.  If you want to keep them,\n"
                 "cancel and write the outputs first." ) );
       mb.addButton( tr( "Ignore Edits" ), QMessageBox::RejectRole );
@@ -8698,7 +8731,7 @@ DbgLv(1) << "EDT:NewTr: tripindex" << triple_index << "chgs" << changes_made << 
       {
          cb_triple->disconnect();
          cb_triple->setCurrentIndex( triple_index );
-         connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+         connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                              SLOT  ( new_triple         ( int ) ) );
          return;
       }
@@ -8713,8 +8746,8 @@ DbgLv(1) << "EDT:NewTr: tripindex" << triple_index << "chgs" << changes_made << 
 
    index_data();
 
-   
-   
+
+
 DbgLv(1) << "EDT:NewTr: trip,data index" << triple_index << data_index;
 
    if ( isMwl )
@@ -8749,10 +8782,10 @@ DbgLv(1) << "EDT:NewTr:  nwavelo" << nwavelo;
    }
 
    // Reset for new triple
-   reset_triple(); 
+   reset_triple();
 
    // Need to reconnect after reset
-   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                        SLOT  ( new_triple_auto    ( int ) ) );
 
    QString otdt   = dataType;
@@ -8766,20 +8799,20 @@ DbgLv(1) << "EDT:NewTr:  nwavelo" << nwavelo;
 	 index_data_auto( triple_index );
        //  }
    ////////////////////////////////////////////////////////////////////////////////
-   
+
    edata          = outData[ data_index ];
    data           = *edata;
 
    qDebug() << "NEW_TRIPLE_AUTO: data_index: " << data_index;
 
-   
+
    QString rawGUID_test1          = US_Util::uuid_unparse( (unsigned char*)data.rawGUID );
    qDebug() << "NEW TRIPLE: Current rawData: rawGUID: " <<  rawGUID_test1;
-   
+
    QString swavl  = cb_lplot ->currentText();
    QString triple = cb_triple->currentText() + ( isMwl ? " / " + swavl : "" );
    int     idax   = triples.indexOf( triple );
-   dataType = QString( QChar( data.type[ 0 ] ) ) 
+   dataType = QString( QChar( data.type[ 0 ] ) )
             + QString( QChar( data.type[ 1 ] ) );
 DbgLv(1) << "EDT:NewTr:   sw tri dx" << swavl << triple << idax << "dataType" << dataType
  << "gap_fringe gap_thresh" << gap_fringe << gap_thresh;
@@ -8816,7 +8849,7 @@ DbgLv(1) << "EDT:NewTr:   sw tri dx" << swavl << triple << idax << "dataType" <<
    //pb_undo     ->setEnabled( true );
 
 
-   //qDebug() << "In new triple_auto: all_edits, isMw: " << all_edits << ", " << isMwl; 
+   //qDebug() << "In new triple_auto: all_edits, isMw: " << all_edits << ", " << isMwl;
 
    all_edits = true;
    pb_write    ->setEnabled( all_edits );
@@ -8832,7 +8865,7 @@ DbgLv(1) << "EDT:NewTr:   sw tri dx" << swavl << triple << idax << "dataType" <<
    connect( ct_to,   SIGNAL( valueChanged ( double ) ),
                      SLOT  ( focus_to     ( double ) ) );
 
-   connect( ct_gaps, SIGNAL( valueChanged        ( double ) ), 
+   connect( ct_gaps, SIGNAL( valueChanged        ( double ) ),
                      SLOT  ( set_fringe_tolerance( double ) ) );
 
    if ( expIsEquil )
@@ -8902,13 +8935,13 @@ DbgLv(1) << "EDT:NewTr:   men" << meniscus << "dx" << idax;
       ct_gaps->setNumButtons( 3 );
 DbgLv(1) << " 2)gap_fringe" << gap_fringe << "idax" << idax;
 
-      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ), 
+      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ),
                         SLOT  ( set_fringe_tolerance( double ) ) );
    }
    else
    {
       lb_gaps->setText( tr( "Threshold for Scan Gaps" ) );
-      
+
       ct_gaps->disconnect   ();
       ct_gaps->setRange     ( 10.0, 100.0 );
       ct_gaps->setSingleStep( 10.0 );
@@ -8928,14 +8961,14 @@ DbgLv(1) << " 2)gap_fringe" << gap_fringe << "idax" << idax;
    int scanExcl_begin_ind = editProfile_scans_excl[ cb_triple->currentText() ][0].toInt();
    int scanExcl_end_ind   = editProfile_scans_excl[ cb_triple->currentText() ][1].toInt();
 
-   qDebug() << "IN new_Triple_auto(): triple -- " << cb_triple->currentText() 
+   qDebug() << "IN new_Triple_auto(): triple -- " << cb_triple->currentText()
    	    << "ScanBegin -- " << scanExcl_begin_ind
    	    << "ScanEnd -- "   << scanExcl_end_ind ;
 
    qDebug() << "Includes size before remove: " << includes.size();
    //for ( int i = 0; i < includes.size(); ++i  )
    //  qDebug() << "Includes after remove: " << includes[ i ];
-   
+
    for ( int ii = 0; ii < scanExcl_begin_ind; ii++ )
      {
        includes.removeFirst();
@@ -8949,13 +8982,13 @@ DbgLv(1) << " 2)gap_fringe" << gap_fringe << "idax" << idax;
    //Also, for "ABDE", remove from includes all by manuall editing
    if ( autoflow_expType == "ABDE" && edited_triples_abde[ cb_triple->currentText() ] )
      includes = editProfile_includes[ cb_triple->currentText() ];
-   
+
    qDebug() << "Includes" << includes;
    qDebug() << "Includes size after remove: " << includes.size();
    //for ( int i = 0; i < includes.size(); ++i  )
    //  qDebug() << "Includes after remove: " << includes[ i ];
    ///////////////////////////////////////////////////////////
-   
+
    replot();
 DbgLv(1) << "EDT:NewTr: DONE";
 
@@ -8965,7 +8998,7 @@ DbgLv(1) << "EDT:NewTr: DONE";
 //qDebug() << "Triple: " << triple << ", cb_triple_text: " << cb_triple->currentText();
 //qDebug() << editProfile[ triple ] << ", " <<  editProfile[ cb_triple->currentText() ];
 
- qDebug() << "EDT:NewTr:all_loaded -- " << all_loaded; 
+ qDebug() << "EDT:NewTr:all_loaded -- " << all_loaded;
 
  //disconnect pick for main[AUTO] mode
  qDebug() << "[BEGIN]us_edit_auto_mode - " << us_edit_auto_mode;
@@ -8975,8 +9008,8 @@ DbgLv(1) << "EDT:NewTr: DONE";
  QString wvl_value = ( isMwl ? swavl : cb_triple->currentText().split("/")[2].trimmed() );
  qDebug() << "wvl_value -- " << wvl_value;
 
- 
- if ( all_loaded ) 
+
+ if ( all_loaded )
    {
      if ( autoflow_expType == "ABDE" )
        {
@@ -8993,17 +9026,17 @@ DbgLv(1) << "EDT:NewTr: DONE";
 	     pb_bll_modify -> setEnabled( true );
 	   }
        }
-     
+
      qDebug() << "NEW_TRIPLE_AUTO: all_loaded: " << all_loaded;
 
      qDebug() << "NEW_TRIPLE_AUTO: editProfile.count(): " << editProfile.count();
-     
+
      // Debug
      for (int index = 0; index < cb_triple->count(); index++)
        qDebug() << cb_triple->itemText(index);
 
      qDebug() << "Current Triple: " << cb_triple->currentText();
-     
+
      meniscus      = editProfile[ cb_triple->currentText() ][0].toDouble();
      range_left    = editProfile[ cb_triple->currentText() ][1].toDouble();
      range_right   = editProfile[ cb_triple->currentText() ][2].toDouble();
@@ -9017,31 +9050,31 @@ DbgLv(1) << "EDT:NewTr: DONE";
        {
 	 // QString wvl_value = ( isMwl ? swavl : cb_triple->currentText().split("/")[2].trimmed() );
 	 // qDebug() << "wvl_value -- " << wvl_value;
-	 
+
 	 bl_corr_slope      = editProfile_blc[ cb_triple->currentText() ][ wvl_value ][0].toDouble();
 	 bl_corr_yintercept = editProfile_blc[ cb_triple->currentText() ][ wvl_value ][1].toDouble();
 
 	 le_bll_slope       ->setText( QString::number( bl_corr_slope,      'f', 3 ) );
 	 le_bll_intercept   ->setText( QString::number( bl_corr_yintercept, 'f', 3 ) );
        }
-     
+
      le_meniscus ->setText( QString::number( meniscus,   'f', 3 ) );
      le_dataStart->setText( QString::number( range_left, 'f', 3 ) );
      le_dataEnd  ->setText( QString::number( range_right, 'f', 3 ) );
      le_plateau  ->setText( QString::number( plateau,     'f', 3 ) );
 
      qDebug() << "NEW_TRIPLE_AUTO: 2";
-     
-     if ( isMwl ) 
+
+     if ( isMwl )
        le_baseline ->setText( QString::number( baseline,     'f', 3 ) );
      else
        {
 	 QString str;
-	 le_baseline->setText( str.sprintf( "%.3f (%.3e)", baseline, baseline_od ) );   
+	 le_baseline->setText( str.sprintf( "%.3f (%.3e)", baseline, baseline_od ) );
        }
 
      qDebug() << "NEW_TRIPLE_AUTO: 3";
-     
+
      if ( editProfile[ cb_triple->currentText() ].count() > 6 )
        {
      	 if ( editProfile[ cb_triple->currentText() ][6] == "spike_true")
@@ -9062,25 +9095,25 @@ DbgLv(1) << "EDT:NewTr: DONE";
      if ( dataType == "IP" )
        {
 	 qDebug() << "NEW_TRIPLE_AUTO: 4a - IN IP";
-	 
+
 	 airGap_left   = editProfile[ cb_triple->currentText() ][7].toDouble();
 	 airGap_right  = editProfile[ cb_triple->currentText() ][8].toDouble();
 
 	 QString wkstr;
-	 le_airGap->setText( wkstr.sprintf( "%.3f - %.3f", 
+	 le_airGap->setText( wkstr.sprintf( "%.3f - %.3f",
 					    airGap_left, airGap_right ) );
-	 
+
 	 US_DataIO::EditValues  edits;
 	 edits.airGapLeft  = airGap_left;
 	 edits.airGapRight = airGap_right;
-	 
+
 	 QList< int > excludes;
-         
+
 	 for ( int i = 0; i < data.scanData.size(); i++ )
 	   if ( ! includes.contains( i ) ) edits.excludes << i;
-	   
+
 	 US_DataIO::adjust_interference( data, edits );
-	 
+
 	 edits.rangeLeft    = range_left;
 	 edits.rangeRight   = range_right;
 	 edits.gapTolerance = ct_gaps->value();
@@ -9089,7 +9122,7 @@ DbgLv(1) << "EDT:NewTr: DONE";
        }
 
      qDebug() << "NEW_TRIPLE_AUTO: 5";
-     
+
      //plot_range();
      if ( autoflow_expType == "ABDE")
        plot_range_and_blc( );
@@ -9099,10 +9132,10 @@ DbgLv(1) << "EDT:NewTr: DONE";
 
  //disconnect pick for main[AUTO] mode
  qDebug() << "[END]us_edit_auto_mode - " << us_edit_auto_mode;
- qDebug() << "Includes: " << includes; 
+ qDebug() << "Includes: " << includes;
  if ( us_edit_auto_mode )
    pick -> disconnect();
- 
+
 }
 
 //[ABDE-MWL] before changing wvl, set current baseline
@@ -9113,7 +9146,7 @@ void US_Edit::set_current_bll_abde( QString chann, QString swave )
 
   bl_corr_slope      = editProfile_blc[ chann ][swave][0].toDouble();
   bl_corr_yintercept = editProfile_blc[ chann ][swave][1].toDouble();
-  
+
   le_bll_slope       ->setText( QString::number( bl_corr_slope,      'f', 3 ) );
   le_bll_intercept   ->setText( QString::number( bl_corr_yintercept, 'f', 3 ) );
 
@@ -9132,7 +9165,7 @@ DbgLv(1) << "EDT:NewTr: tripindex" << triple_index << "chgs" << changes_made << 
       QMessageBox mb;
       mb.setIcon( QMessageBox::Question );
       mb.setText( tr( "Ignore Edits?" ) );
-      mb.setInformativeText( 
+      mb.setInformativeText(
             tr( "Edits have been made.  If you want to keep them,\n"
                 "cancel and write the outputs first." ) );
       mb.addButton( tr( "Ignore Edits" ), QMessageBox::RejectRole );
@@ -9143,7 +9176,7 @@ DbgLv(1) << "EDT:NewTr: tripindex" << triple_index << "chgs" << changes_made << 
       {
          cb_triple->disconnect();
          cb_triple->setCurrentIndex( triple_index );
-         connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+         connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                              SLOT  ( new_triple         ( int ) ) );
          return;
       }
@@ -9190,10 +9223,10 @@ DbgLv(1) << "EDT:NewTr:  nwavelo" << nwavelo;
    }
 
    // Reset for new triple
-   reset_triple(); 
+   reset_triple();
 
    // Need to reconnect after reset
-   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                        SLOT  ( new_triple         ( int ) ) );
 
    QString otdt   = dataType;
@@ -9202,7 +9235,7 @@ DbgLv(1) << "EDT:NewTr:  nwavelo" << nwavelo;
    QString swavl  = cb_lplot ->currentText();
    QString triple = cb_triple->currentText() + ( isMwl ? " / " + swavl : "" );
    int     idax   = triples.indexOf( triple );
-   dataType = QString( QChar( data.type[ 0 ] ) ) 
+   dataType = QString( QChar( data.type[ 0 ] ) )
             + QString( QChar( data.type[ 1 ] ) );
 DbgLv(1) << "EDT:NewTr:   sw tri dx" << swavl << triple << idax << "dataType" << dataType
  << "gap_fringe gap_thresh" << gap_fringe << gap_thresh;
@@ -9250,7 +9283,7 @@ DbgLv(1) << "EDT:NewTr:   sw tri dx" << swavl << triple << idax << "dataType" <<
    connect( ct_to,   SIGNAL( valueChanged ( double ) ),
                      SLOT  ( focus_to     ( double ) ) );
 
-   connect( ct_gaps, SIGNAL( valueChanged        ( double ) ), 
+   connect( ct_gaps, SIGNAL( valueChanged        ( double ) ),
                      SLOT  ( set_fringe_tolerance( double ) ) );
 
    if ( expIsEquil )
@@ -9318,7 +9351,7 @@ DbgLv(1) << "EDT:NewTr:      jdax ldax" << jdax << ldax;
 
          QString trtype   = isMwl ? "cell/channel" : "triple";
          QString trvalu   = isMwl ? trbase         : triple;
-DbgLv(1) << "EDT:NewTr:   tr type,valu" << trtype << trvalu; 
+DbgLv(1) << "EDT:NewTr:   tr type,valu" << trtype << trvalu;
 
          QMessageBox mbox;
          QPushButton* pb_appl;
@@ -9374,13 +9407,13 @@ DbgLv(1) << "EDT:NewTr:   men" << meniscus << "dx" << idax;
       ct_gaps->setNumButtons( 3 );
 DbgLv(1) << " 2)gap_fringe" << gap_fringe << "idax" << idax;
 
-      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ), 
+      connect( ct_gaps, SIGNAL( valueChanged        ( double ) ),
                         SLOT  ( set_fringe_tolerance( double ) ) );
    }
    else
    {
       lb_gaps->setText( tr( "Threshold for Scan Gaps" ) );
-      
+
       ct_gaps->disconnect   ();
       ct_gaps->setRange     ( 10.0, 100.0 );
       ct_gaps->setSingleStep( 10.0 );
@@ -9488,7 +9521,7 @@ bool US_Edit::isSaved_auto( void )
    US_Passwd pw;
    QString masterpw = pw.getPasswd();
    US_DB2* db = new US_DB2( masterpw );
-   
+
    if ( db->lastErrno() != US_DB2::OK )
      {
        QMessageBox::information( this,
@@ -9506,7 +9539,7 @@ bool US_Edit::isSaved_auto( void )
 
     qDebug() << "Query: " << qry;
     qDebug() << "# Saved Edit Profiles: " << editProfile_count;
-    
+
     if ( editProfile_count  )
       isDataSaved = true;
 
@@ -9518,7 +9551,7 @@ bool US_Edit::isSaved_auto( void )
 int US_Edit::read_autoflow_stages_record( int autoflowID  )
 {
    int status = 0;
-  
+
    // Check DB connection
    US_Passwd pw;
    QString masterpw = pw.getPasswd();
@@ -9536,7 +9569,7 @@ int US_Edit::read_autoflow_stages_record( int autoflowID  )
    QStringList qry;
    qry << "autoflow_edit_status"
        << QString::number( autoflowID );
-   
+
    status = db->statusQuery( qry );
    //qDebug() << "AFTER query ";
 
@@ -9557,15 +9590,15 @@ void US_Edit::revert_autoflow_stages_record( int autoflowID )
 			     tr( "Read protocol: Could not connect to database \n" ) + db->lastError() );
        return;
      }
-   
+
    //qDebug() << "BEFORE query ";
    QStringList qry;
    qry << "autoflow_edit_status_revert"
        << QString::number( autoflowID );
-   
+
    db->query( qry );
    //qDebug() << "AFTER query ";
-   
+
 }
 
 // Query autoflow record
@@ -9577,7 +9610,7 @@ QMap< QString, QString> US_Edit::read_autoflow_record( int autoflowID  )
    US_DB2* db = new US_DB2( masterpw );
 
    QMap <QString, QString> protocol_details;
-   
+
    if ( db->lastErrno() != US_DB2::OK )
      {
        QMessageBox::warning( this, tr( "Connection Problem" ),
@@ -9588,7 +9621,7 @@ QMap< QString, QString> US_Edit::read_autoflow_record( int autoflowID  )
    QStringList qry;
    qry << "read_autoflow_record"
        << QString::number( autoflowID );
-   
+
    db->query( qry );
 
    if ( db->lastErrno() == US_DB2::OK )      // Autoflow record exists
@@ -9603,7 +9636,7 @@ QMap< QString, QString> US_Edit::read_autoflow_record( int autoflowID  )
 	   protocol_details[ "experimentId" ]   = db->value( 5 ).toString();
 	   protocol_details[ "runID" ]          = db->value( 6 ).toString();
 	   protocol_details[ "status" ]         = db->value( 7 ).toString();
-           protocol_details[ "dataPath" ]       = db->value( 8 ).toString();   
+           protocol_details[ "dataPath" ]       = db->value( 8 ).toString();
 	   protocol_details[ "OptimaName" ]     = db->value( 9 ).toString();
 	   protocol_details[ "runStarted" ]     = db->value( 10 ).toString();
 	   protocol_details[ "invID_passed" ]   = db->value( 11 ).toString();
@@ -9618,7 +9651,7 @@ QMap< QString, QString> US_Edit::read_autoflow_record( int autoflowID  )
 
 	   protocol_details[ "expType" ]       = db->value( 26 ).toString();
 	   protocol_details[ "dataSource" ]     = db->value( 27 ).toString();
-	   	   
+
 	 }
      }
 
@@ -9640,7 +9673,7 @@ void US_Edit::correct_bll_for_triple_auto( void )
 
   QStringList editParams          = editProfile[ cb_triple->currentText() ];
   QList<int>  editParams_includes = editProfile_includes[ cb_triple->currentText() ];
-  
+
   sdiag_bll = new US_Edit( allData, triples, workingDir, currChIndex, plotInd, autoflow_expType,
 		       editParams, editParams_includes );
   sdiag_bll->setParent(this, Qt::Widget);
@@ -9653,7 +9686,7 @@ void US_Edit::correct_bll_for_triple_auto( void )
 
   //connect( sdiag_bll, SIGNAL( pass_edit_params_blc_plot( int ) ),
   //	   this,  SLOT( update_triple_edit_params_blc_modified_plot ( int ) ) );
-  
+
   connect( sdiag_bll, SIGNAL( restore_main_view( ) ), this, SLOT( restore_view( ) ) );
 
   sdiag_bll->show();
@@ -9667,7 +9700,7 @@ void US_Edit::correct_bll_for_triple_auto( void )
   sdiag_bll->resize( QSize(newWidth, newHeight ));
   sdiag_bll->update();
   sdiag_bll->update();
-  
+
 }
 
 
@@ -9684,17 +9717,17 @@ void US_Edit::manual_edit_auto( void )
       delete sdiag;
       sdiag = NULL;
     }
-  
+
   int currChIndex = cb_triple->currentIndex();
   //int plotInd = index_data();
   int plotInd = plotndx;
   qDebug() << "IN manual_edit_auto( void ), plotInd -- " << plotInd;
-  
+
   sdiag = new US_Edit( allData, triples, workingDir, currChIndex, plotInd, autoflow_expType );
   sdiag->setParent(this, Qt::Widget);
   sdiag->setFrameShape( QFrame::Box);
   sdiag->setLineWidth(2);
-  
+
   // sdiag->setWindowFlags( Qt::Dialog | Qt::WindowTitleHint | Qt::WindowMinimizeButtonHint);
   // sdiag->setWindowModality(Qt::ApplicationModal);
   /***************************************************************************************************/
@@ -9721,7 +9754,7 @@ void US_Edit::manual_edit_auto( void )
   //sdiag->adjustSize();
   sdiag->resize( QSize(newWidth, newHeight ));
   sdiag->update();
- 
+
   sdiag->show();
   //sdiag->trigger_resize();
   //resize_main ( );
@@ -9736,7 +9769,7 @@ void US_Edit::manual_edit_auto( void )
 void US_Edit::restore_view( void )
 {
   pick     ->disconnect();
-  
+
   //show parent layouts
   upperWidget -> show();
   leftWidget  -> show();
@@ -9753,10 +9786,10 @@ void US_Edit::update_triple_edit_params_blc_modified(  QMap < QString, QStringLi
   rightWidget -> show();
 
   us_edit_auto_mode = true;
-  
+
   QString t_name = edit_params_blc.keys()[0];
   QString w_c;
-  
+
   if ( isMwl )
     {
       w_c = cb_lplot->currentText();
@@ -9771,13 +9804,13 @@ void US_Edit::update_triple_edit_params_blc_modified(  QMap < QString, QStringLi
     }
 
   //replot
-  new_triple_auto( 0 ); 
+  new_triple_auto( 0 );
 }
 
 // void US_Edit::update_triple_edit_params_blc_modified_plot( int currInd )
 // {
 //   //replot
-//   new_triple_auto( currInd ); 
+//   new_triple_auto( currInd );
 // }
 
 
@@ -9809,12 +9842,12 @@ void US_Edit::update_triple_edit_params_blc (  QMap < QString, QStringList > &  
 void US_Edit::update_triple_edit_params_includes (  QMap < QString, QList<int> > &  edit_params_includes )
 {
   pick     ->disconnect();
-  
+
   //show parent layouts
   upperWidget -> show();
   leftWidget  -> show();
   rightWidget -> show();
-  
+
   QString t_name = edit_params_includes.keys()[0];
   editProfile_includes[ t_name ] = edit_params_includes[ t_name ];
 
@@ -9843,12 +9876,12 @@ void US_Edit::update_triple_edit_params (  QMap < QString, QStringList > &  edit
       QString comment_t    = QInputDialog::getText( this,
 						    tr( "Reason for MANUAL editing" ),
 						    msg, QLineEdit::Normal, default_text, &ok );
-      
+
       if ( !ok )
 	{
 	  return;
 	}
-      
+
       manual_edit_comments[ t_name ] = comment_t;
     }
   else
@@ -9856,10 +9889,10 @@ void US_Edit::update_triple_edit_params (  QMap < QString, QStringList > &  edit
       edited_triples_abde[ t_name ] = true;
       setUnsetSaveBttn_abde();
     }
-      
+
   ///////////////////////////////////////////////////////
 
-  new_triple_auto( 0 ); 
+  new_triple_auto( 0 );
 }
 
 //for ABDE, check if all triples were processed & enable/diable Save
@@ -9885,14 +9918,14 @@ void US_Edit::write_auto( void )
   // //TEMP: DEBUG!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
   // record_edit_status( automatic_meniscus, dataType );
   // exit(1);
-  
+
   /****  TEMP1 **/
   //--- Check if saving already initiated
   int status_edit_unique;
   status_edit_unique = read_autoflow_stages_record( autoflowID_passed );
 
   qDebug() << "status_edit_unique -- " << status_edit_unique ;
-  
+
   if ( !status_edit_unique )
     {
 
@@ -9905,15 +9938,15 @@ void US_Edit::write_auto( void )
   				    "The program will return to the autoflow runs dialog where "
   				    "you can re-attach to the actual current stage of the run. "
   				    "Please allow some time for the status to be updated.") );
-   
-   
+
+
       reset();
       emit back_to_initAutoflow( );
       return;
     }
     //-------------------------------------------
   /***/
-  
+
   pb_write       ->setEnabled( false );
 
   /*
@@ -9921,15 +9954,15 @@ void US_Edit::write_auto( void )
   for ( int i = 0; i < triples.size(); ++i )
     {
       //qDebug() << "Triple name: " << triples[i];
-	  
+
       QString current_triple_name = triples[i];
       current_triple_name.replace(" / ",".");
-      
+
       QStringList triple_parts = current_triple_name.split(".");
-      
+
       if ( dataType == "IP" )
 	current_triple_name = triple_parts[0] + "." + triple_parts[1] + "." + QString("Interference");
-      
+
       triples_all_optics << current_triple_name;
       channels_all << triple_parts[0] + "." + triple_parts[1];
     }
@@ -9940,7 +9973,7 @@ void US_Edit::write_auto( void )
       qDebug() << channels_all[i];
       isSet_ref_wvl[ channels_all[i] ] = false;
     }
-  
+
   // Process by channel
   for ( int i = 0; i < channels_all.size(); ++i  )
     {
@@ -9963,16 +9996,16 @@ void US_Edit::write_auto( void )
 	    }
 	}
     }
-  
+
   return;
   // Test
   */
-  
-      
+
+
   /** Check if stage is being or has already changed ***/
   QMap < QString, QString > autoflow_details;
   autoflow_details = read_autoflow_record( autoflowID_passed );
-  
+
   qDebug() << "autoflowID_passed, autoflow status, isSaved_auto(): " <<  autoflowID_passed << ", " << autoflow_details[ "status" ]; // << ", " << isSaved_auto();
 
   // Check if all optics systems were processed //
@@ -9993,15 +10026,15 @@ void US_Edit::write_auto( void )
   for ( int i = 0; i < triples.size(); ++i )
     {
       //qDebug() << "Triple name: " << triples[i];
-      
+
       QString current_triple_name = triples[i];
       current_triple_name.replace(" / ",".");
-      
+
       QStringList triple_parts = current_triple_name.split(".");
-      
+
       if ( dataType == "IP" )
 	current_triple_name = triple_parts[0] + "." + triple_parts[1] + "." + QString("Interference");
-      
+
       triples_all_optics << current_triple_name;
       channels_all << triple_parts[0] + "." + triple_parts[1];
     }
@@ -10021,11 +10054,11 @@ void US_Edit::write_auto( void )
 
    	      cb_triple->disconnect();
 
-   	      
+
    	      //set autoflowStages record to "unknown" again !!
    	      revert_autoflow_stages_record( autoflowID_passed );
-   	      
-   	      
+
+
    	      reset();
    	      emit process_next_optics( );
    	      return;
@@ -10041,8 +10074,8 @@ void US_Edit::write_auto( void )
    					    "The program will return to the autoflow runs dialog where "
    					    "you can re-attach to the actual current stage of the run. "
    					    "Please allow some time for the status to be updated.") );
-   	      
-   	      
+
+
    	      reset();
    	      emit back_to_initAutoflow( );
    	      return;
@@ -10059,17 +10092,17 @@ void US_Edit::write_auto( void )
    					"The program will return to the autoflow runs dialog where "
    					"you can re-attach to the actual current stage of the run. "
    					"Please allow some time for the status to be updated.") );
-   	  
-   	  
+
+
    	  reset();
    	  emit back_to_initAutoflow( );
    	  return;
    	}
      }
   /***/
-  
+
   /*******************************************************/
-  
+
    // Determine if we are using the database
    US_DB2* dbP  = NULL;
 
@@ -10086,7 +10119,7 @@ void US_Edit::write_auto( void )
       }
    }
 
-   
+
    /*************************************************************************************************************/
    // We need to  insert submission form dialog (with password...)
    /*************************************************************************************************************/
@@ -10098,38 +10131,38 @@ void US_Edit::write_auto( void )
    QString u_fname = dbP-> value( 1 ).toString();
    QString u_lname = dbP-> value( 2 ).toString();
    int u_lev       = dbP-> value( 5 ).toInt();
-   
+
    QString user_submitter = u_lname + ", " + u_fname;
-   
+
    gmp_submitter_map.clear();
    US_Passwd   pw_at;
    gmp_submitter_map  = pw_at.getPasswd_auditTrail( "GMP Run EDIT Form", "Please fill out GMP run EDIT form:", user_submitter );
-   
+
    int gmp_submitter_map_size = gmp_submitter_map.keys().size();
    qDebug() << "Submitter map: "
 	    << gmp_submitter_map.keys()  << gmp_submitter_map.keys().size() << gmp_submitter_map_size
-	    << gmp_submitter_map.keys().isEmpty() 
+	    << gmp_submitter_map.keys().isEmpty()
 	    << gmp_submitter_map[ "User:" ]
 	    << gmp_submitter_map[ "Comment:" ]
 	    << gmp_submitter_map[ "Master Password:" ];
-   
+
    if ( gmp_submitter_map_size == 0 ||  gmp_submitter_map.keys().isEmpty() )
      {
        revert_autoflow_stages_record( autoflowID_passed );
        pb_write       ->setEnabled( true );
 
-       //DEBUG 
+       //DEBUG
        for ( int i = 0; i < channels_all.size(); ++i  )
 	 qDebug() << "[NO COMMMENT] BEFORE AUTOFLOW_ANALYSIS: channel name --" << channels_all[i];
        for ( int j = 0; j < triples_all_optics.size(); ++j )
 	 qDebug() << "[NO COMMNET] BEFORE AUTOFLOW_ANALYSIS: triple name -- " << triples_all_optics[j];
        //END DEBUG
-       
+
        return;
      }
    /*************************************************************************************************************/
-   
-   qDebug() << "NOW, START Saving"; 
+
+   qDebug() << "NOW, START Saving";
 
 
    /* TEMPORARY ***/
@@ -10160,7 +10193,7 @@ void US_Edit::write_auto( void )
       {  // Write single triple's edit
 
 	qDebug() << "Saving non-MWL";
-	
+
 	// if ( dataType != "IP" )
 	//   {
 	    for ( int trx = 0; trx < cb_triple->count(); trx++ )
@@ -10173,10 +10206,10 @@ void US_Edit::write_auto( void )
 	//   {
 	//     // <---- For now: for Interference data, do editing && save manually
 	//     triple_index = cb_triple->currentIndex();
-	//     bottom = centerpieceParameters[ triple_index ][1].toDouble();  //Should be from centerpiece info from protocol 
-	//     write_triple();           
+	//     bottom = centerpieceParameters[ triple_index ][1].toDouble();  //Should be from centerpiece info from protocol
+	//     write_triple();
 	//   }
-	  
+
       }
    }
 
@@ -10198,15 +10231,15 @@ void US_Edit::write_auto( void )
    // for ( int i = 0; i < triples.size(); ++i )
    //   {
    //     //qDebug() << "Triple name: " << triples[i];
-       
+
    //     QString current_triple_name = triples[i];
    //     current_triple_name.replace(" / ",".");
-      
+
    //     QStringList triple_parts = current_triple_name.split(".");
-       
+
    //     if ( dataType == "IP" )
    // 	 current_triple_name = triple_parts[0] + "." + triple_parts[1] + "." + QString("Interference");
-       
+
    //     triples_all_optics << current_triple_name;
    //     channels_all << triple_parts[0] + "." + triple_parts[1];
    //   }
@@ -10217,16 +10250,16 @@ void US_Edit::write_auto( void )
 
    //Now, make a record on was the Reference Scan defined automatically (for "RI" type) && who did SAVE the data
    record_edit_status( automatic_meniscus, dataType );
-   
+
    //////////////////////////////////////////////////////////////
-   
+
    if ( !all_processed )
      {
        /****/
        //set autoflowStages record to "unknown" again !!
        revert_autoflow_stages_record( autoflowID_passed );
        /****/
-       
+
        reset();
        emit process_next_optics( );
        return;
@@ -10245,7 +10278,7 @@ void US_Edit::write_auto( void )
    if ( autoflow_expType == "ABDE" )
      {
        qDebug() << "EDIT STOPS HERE for ABDE!!!";
-       
+
        //Just update status of autoflow record (to 'ANALYSIS' with no analysisIDs)
        //update_autoflow_record_atEditData_abde( dbP );
        QString AnalysisIDsstr = QString("NULL");
@@ -10259,20 +10292,20 @@ void US_Edit::write_auto( void )
        this->close();
        qApp->processEvents();
        //emit to ANALYSIS? <----------------
-       emit edit_complete_auto( details_at_editing_local  );   
+       emit edit_complete_auto( details_at_editing_local  );
        //emit to REPORT? <----------------
-       //emit edit_complete_auto_abde( details_at_editing_local  );   
+       //emit edit_complete_auto_abde( details_at_editing_local  );
        return;
      }
   /////////////////////////////////////////////////////////////////////
-   
 
-   
-   // Now, remove duplicates from channels array, fill QMap keeping track on if reference wavelength set for each channel (if MWL) 
+
+
+   // Now, remove duplicates from channels array, fill QMap keeping track on if reference wavelength set for each channel (if MWL)
    channels_all       .removeDuplicates();
    triples_all_optics .removeDuplicates(); //Absence of this caused incorrect analyses list: need to test!!!
-   
-     
+
+
    for ( int i = 0; i < channels_all.size(); ++i  )
      {
        qDebug() << "BEFORE AUTOFLOW_ANALYSIS: channel name --" << channels_all[i]; // RA:S:: "1.S"
@@ -10282,11 +10315,11 @@ void US_Edit::write_auto( void )
    //DEBUG
    for ( int j = 0; j < triples_all_optics.size(); ++j )
      qDebug() << "BEFORE AUTOFLOW_ANALYSIS: triple name -- " << triples_all_optics[j]; //RA:S:: "1.S.280"
-   
-   
+
+
    // Process triples by channel, generate appropriate JSON (with or without 2DSA_FM stage) for autoflowAnalysis record && create those records
    QStringList AnalysisIDs;
-   
+
    for ( int i = 0; i < channels_all.size(); ++i  )
      {
        qDebug() << "AUTOFLOW_ANALYSIS: channel name -- " << channels_all[i];
@@ -10295,10 +10328,10 @@ void US_Edit::write_auto( void )
 	   if ( triples_all_optics[j].contains( channels_all[i] ) )
 	     {
 	       qDebug() << "AUTOFLOW_ANALYSIS: triple " << triples_all_optics[j] <<  " ,containing channel " <<  channels_all[i];
-	       
+
 	       int ID = 0;
 	       QString json_status;
-	       
+
 	       //Interference
 	       if ( triples_all_optics[j].contains( "Interference" ) )
 		 {
@@ -10309,18 +10342,18 @@ void US_Edit::write_auto( void )
 		       //Need to use "-IP"
 		       if ( runType_combined_IP_RI )
 			 filename_runID_auto = filename_runID_auto_base + "-IP";
-		       
+
 		       json_status = compose_json( true );
 		       qDebug() << triples_all_optics[j] << json_status;
 
 		       ID = create_autoflowAnalysis_record( dbP, triples_all_optics[j], json_status );
-		       
+
 		       if (ID)
 			 create_autoflowAnalysisStages_record( dbP, ID );
 		     }
 		 }
 	       //UV.vis
-	       else		 
+	       else
 		 {
 		   if ( isSet_to_analyse( triples_all_optics[ j ],  QString("UV/vis") ) &&
 			isSet_to_analyse_triple( triples_all_optics[ j ],  QString("UV/vis") ) )
@@ -10330,7 +10363,7 @@ void US_Edit::write_auto( void )
 		       if ( runType_combined_IP_RI )
 			 filename_runID_auto = filename_runID_auto_base + "-RI";
 
-		       // Was channel's reference wvl set? 		       
+		       // Was channel's reference wvl set?
 		       if ( !isSet_ref_wvl[ channels_all[i] ] )
 			 {
 			   // If there is an infortmaiton on specific triple to edit (for a current channel) in the AProfile?
@@ -10342,12 +10375,12 @@ void US_Edit::write_auto( void )
 				 {
 				   json_status = compose_json( true );
 				   qDebug() << "isSet_to_edit_triple() TRUE: " << triples_all_optics[j] << json_status;
-				   
+
 				   ID = create_autoflowAnalysis_record( dbP, triples_all_optics[j], json_status );
-				   
+
 				   //So, reference wvl is defiend as the triple specified in AProfile
 				   isSet_ref_wvl[ channels_all[i] ] = true;
-				   
+
 				   if (ID)
 				     create_autoflowAnalysisStages_record( dbP,  ID );
 				 }
@@ -10355,7 +10388,7 @@ void US_Edit::write_auto( void )
 				 {
 				   json_status = compose_json( false );
 				   qDebug() << "isSet_to_edit_triple() FALSE: " << triples_all_optics[j] << json_status;
-				   
+
 				   ID = create_autoflowAnalysis_record( dbP, triples_all_optics[j], json_status );
 				 }
 			     }
@@ -10364,12 +10397,12 @@ void US_Edit::write_auto( void )
 			     {
 			       json_status = compose_json( true );
 			       qDebug() << "isSet_edit_info_for_channel() FALSE: " << triples_all_optics[j] << json_status;
-			       
+
 			       ID = create_autoflowAnalysis_record( dbP, triples_all_optics[j], json_status );
 
 			       //So, reference wvl is defiend as the 1st one in the channel domain
 			       isSet_ref_wvl[ channels_all[i] ] = true;
-			       
+
 			       if (ID)
 				 create_autoflowAnalysisStages_record( dbP,  ID );
 			     }
@@ -10378,20 +10411,20 @@ void US_Edit::write_auto( void )
 			 {
 			   json_status = compose_json( false );
 			   qDebug() << triples_all_optics[j] << json_status;
-			   
+
 			   ID = create_autoflowAnalysis_record( dbP, triples_all_optics[j], json_status );
 			 }
 		     }
 		 }
-	       
+
 	       if ( ID )
 		 AnalysisIDs << QString::number( ID );
-	       
+
 	     }
 	 }
      }
-   
-   
+
+
    le_status->setText( tr( "Saving COMPLETE " ) );
    qApp->processEvents();
 
@@ -10408,14 +10441,14 @@ void US_Edit::write_auto( void )
        emit back_to_initAutoflow( );
        return;
      }
-   
+
    // Otherwise, proceed to analysis: Now we need to Update autoflow record, reset GUI && send signal to switch to Analysis stage:
    QString AnalysisIDsString = AnalysisIDs.join(",");
    update_autoflow_record_atEditData( dbP, AnalysisIDsString );
 
    //Pass analsyisIDs generated to details_at_editing_local
    details_at_editing_local[ "analysisIDs" ] = AnalysisIDsString;
-   
+
    //ALEXEY: here major actions on setting analysis tables etc. !!!!
    QMessageBox::information( this,
 			     tr( "Saving of Edit Profiles is Complete." ),
@@ -10424,8 +10457,8 @@ void US_Edit::write_auto( void )
    reset();
    this->close();
    qApp->processEvents();
-   
-   emit edit_complete_auto( details_at_editing_local  );   
+
+   emit edit_complete_auto( details_at_editing_local  );
 }
 
 //Record statuses of the auto/manual meniscus determinaiton, on per-channel basis
@@ -10442,14 +10475,14 @@ void US_Edit::record_edit_status( QMap< QString, bool> auto_meniscus, QString dt
   US_Passwd pw;
   QString masterpw = pw.getPasswd();
   US_DB2* db = new US_DB2( masterpw );
-  
+
   if ( db->lastErrno() != US_DB2::OK )
     {
       QMessageBox::warning( this, tr( "Connection Problem" ),
 			    tr( "Read protocol: Could not connect to database \n" ) + db->lastError() );
       return;
     }
-  
+
   QStringList qry;
 
   //get user info
@@ -10465,14 +10498,14 @@ void US_Edit::record_edit_status( QMap< QString, bool> auto_meniscus, QString dt
   int     level = db->value( 5 ).toInt();
 
   qDebug() << "IN US_edit_AUTO, record status: ID,name,email,lev" << ID << fname << lname << email << level;
-  
+
   //Record to autoflowStatus:
   qry.clear();
 
   QString editRI_IP_Json;
   editRI_IP_Json. clear();
   editRI_IP_Json += "{ \"Person\": ";
-  
+
   editRI_IP_Json += "[{";
   editRI_IP_Json += "\"ID\":\""     + QString::number( ID )     + "\",";
   editRI_IP_Json += "\"fname\":\""  + fname                     + "\",";
@@ -10482,16 +10515,16 @@ void US_Edit::record_edit_status( QMap< QString, bool> auto_meniscus, QString dt
   editRI_IP_Json += "}],";
 
   //Now, add comment from SAVING form:
-  editRI_IP_Json += "\"Comment when SAVED\": \"" + gmp_submitter_map[ "Comment:" ] + "\",";      
+  editRI_IP_Json += "\"Comment when SAVED\": \"" + gmp_submitter_map[ "Comment:" ] + "\",";
 
   //Meniscus
   editRI_IP_Json += "\"Meniscus\": ";
   editRI_IP_Json += "[{";
-  
+
   for ( os = auto_meniscus.begin(); os != auto_meniscus.end(); ++os )
     {
       QString meniscus_method = os.value() ? QString("automated") : QString("manual");
-      
+
       editRI_IP_Json += "\"" + os.key()  + "\":\"" +   meniscus_method;
 
       if ( !os.value() )
@@ -10501,14 +10534,14 @@ void US_Edit::record_edit_status( QMap< QString, bool> auto_meniscus, QString dt
       else
 	editRI_IP_Json += "\",";
     }
-  
+
   editRI_IP_Json.chop(1);
   editRI_IP_Json += "}]";
-  
+
   editRI_IP_Json += "}";
 
   qDebug() << "in record_edit_status: editRI_IP_Json  -- " << editRI_IP_Json;
-  
+
   if ( autoflowStatusID )
     {
       //update
@@ -10518,7 +10551,7 @@ void US_Edit::record_edit_status( QMap< QString, bool> auto_meniscus, QString dt
 	      << QString::number( autoflowStatusID )
 	      << QString::number( autoflowID_passed )
 	      << editRI_IP_Json;
-	  
+
 	  db->query( qry );
 	}
 
@@ -10528,7 +10561,7 @@ void US_Edit::record_edit_status( QMap< QString, bool> auto_meniscus, QString dt
 	      << QString::number( autoflowStatusID )
 	      << QString::number( autoflowID_passed )
 	      << editRI_IP_Json;
-	  
+
 	  db->query( qry );
 	}
     }
@@ -10537,17 +10570,17 @@ void US_Edit::record_edit_status( QMap< QString, bool> auto_meniscus, QString dt
       QMessageBox::warning( this, tr( "AutoflowStatus Record Problem" ),
 			    tr( "autoflowStatus (EDIT {RI|RA,IP}): There was a problem with identifying "
 				"a record in autoflowStatus table for a given run! \n" ) );
-      
+
       return;
     }
 }
 
 
-//Delete autoflow record 
+//Delete autoflow record
 void US_Edit::delete_autoflow_record( void )
 {
   QString runID_numeric     = details_at_editing_local[ "runID" ];
-  QString OptimaName        = details_at_editing_local[ "OptimaName" ]; 
+  QString OptimaName        = details_at_editing_local[ "OptimaName" ];
 
   // Check DB connection
   US_Passwd pw;
@@ -10571,9 +10604,9 @@ void US_Edit::delete_autoflow_record( void )
    //db->query( qry );
 
    // OR
-   
+
    int status = db->statusQuery( qry );
-   
+
    if ( status == US_DB2::NO_AUTOFLOW_RECORD )
      {
        QMessageBox::warning( this,
@@ -10600,11 +10633,11 @@ bool US_Edit::isSet_to_analyse( QString triple_name, QString opsys )
   if ( channels_to_analyse.isEmpty() )
     {
       qDebug() << "It looks like older protocol is in use: QMap channels_to_analyse is EMPTY!";
-      
+
       have_run = true;
       return have_run;
     }
-  
+
   QStringList triple_name_list = triple_name.split(".");
   QString channel = triple_name_list[0] + triple_name_list[1];
 
@@ -10612,7 +10645,7 @@ bool US_Edit::isSet_to_analyse( QString triple_name, QString opsys )
   if ( dataSource. contains("DiskAUC:Absorbance") && channel.contains("S")  )
     channel = channel.replace("S","A");
   qDebug() << "[isSet_to_analyse()] channel2 -- " << channel;
-  
+
   QMap<QString, bool>::iterator jj;
   for ( jj = channels_to_analyse.begin(); jj != channels_to_analyse.end(); ++jj )
     {
@@ -10621,7 +10654,7 @@ bool US_Edit::isSet_to_analyse( QString triple_name, QString opsys )
 	  if ( jj.value()  )
 	    {
 	      qDebug() << "Triple " << triple_name << " of channel (" << jj.key() << " will be analysed.";
-	      have_run = true;	      
+	      have_run = true;
 	      break;
 	    }
 	}
@@ -10638,11 +10671,11 @@ bool US_Edit::isSet_to_analyse_triple( QString triple_name, QString opsys )
   if ( triples_skip_analysis.isEmpty() )
     {
       qDebug() << "It looks like older protocol is in use: QMap triples_skip_analysis is EMPTY!";
-      
+
       have_run = true;
       return have_run;
     }
-  
+
   QStringList triple_name_list = triple_name.split(".");
   QString channel = triple_name_list[0] + triple_name_list[1];
 
@@ -10650,9 +10683,9 @@ bool US_Edit::isSet_to_analyse_triple( QString triple_name, QString opsys )
   if ( dataSource. contains("DiskAUC:Absorbance") && channel.contains("S")  )
     channel = channel.replace("S","A");
   qDebug() << "[isSet_to_analyse_triple()] channel2 -- " << channel;
-  
-  QString wvl = triple_name_list[2];    
-  
+
+  QString wvl = triple_name_list[2];
+
   QMap<QString, QString>::iterator jj;
   for ( jj = triples_skip_analysis.begin(); jj != triples_skip_analysis.end(); ++jj )
     {
@@ -10663,12 +10696,12 @@ bool US_Edit::isSet_to_analyse_triple( QString triple_name, QString opsys )
 	  if ( wvl_list_skipped.contains( wvl ) )
 	    {
 	      qDebug() << "Triple " << triple_name << " of channel (" << jj.key() << " will NOT be analysed.";
-	      have_run = false;	      
+	      have_run = false;
 	      break;
 	    }
 	}
     }
-  
+
   return have_run;
 }
 
@@ -10676,7 +10709,7 @@ bool US_Edit::isSet_to_analyse_triple( QString triple_name, QString opsys )
 bool US_Edit::isSet_edit_info_for_channel( QString triple_name, QString opsys )
 {
   bool have_set = false;
-    
+
   QStringList triple_name_list = triple_name.split(".");
   QString channel = triple_name_list[0] + triple_name_list[1];
 
@@ -10684,8 +10717,8 @@ bool US_Edit::isSet_edit_info_for_channel( QString triple_name, QString opsys )
   if ( dataSource. contains("DiskAUC:Absorbance") && channel.contains("S")  )
     channel = channel.replace("S","A");
   qDebug() << "[isSet_edit_info_for_channel()] channel2 -- " << channel;
-  
-  
+
+
   QMap<QString, QString>::iterator jj;
   for ( jj = triple_to_edit.begin(); jj != triple_to_edit.end(); ++jj )
     {
@@ -10696,16 +10729,16 @@ bool US_Edit::isSet_edit_info_for_channel( QString triple_name, QString opsys )
 	  if ( !wvl_set_edit.isEmpty() )
 	    {
 	      qDebug() << "Edit Informaiton for channel " << channel << " is SET.";
-	      have_set = true;	      
+	      have_set = true;
 	      break;
 	    }
 	}
     }
-  
+
   return have_set;
 }
 
-			    
+
 bool US_Edit::isSet_to_edit_triple( QString triple_name, QString opsys )
 {
   bool have_run = false;
@@ -10714,11 +10747,11 @@ bool US_Edit::isSet_to_edit_triple( QString triple_name, QString opsys )
   if ( triple_to_edit.isEmpty() )
     {
       qDebug() << "It looks like older protocol is in use: QMap triple_to_edit is EMPTY!";
-      
+
       have_run = true;
       return have_run;
     }
-  
+
   QStringList triple_name_list = triple_name.split(".");
   QString channel = triple_name_list[0] + triple_name_list[1];
 
@@ -10726,9 +10759,9 @@ bool US_Edit::isSet_to_edit_triple( QString triple_name, QString opsys )
   if ( dataSource. contains("DiskAUC:Absorbance") && channel.contains("S")  )
     channel = channel.replace("S","A");
   qDebug() << "[isSet_to_edit_triple()] channel2 -- " << channel;
-  
-  QString wvl = triple_name_list[2];    
-  
+
+  QString wvl = triple_name_list[2];
+
   QMap<QString, QString>::iterator jj;
   for ( jj = triple_to_edit.begin(); jj != triple_to_edit.end(); ++jj )
     {
@@ -10739,12 +10772,12 @@ bool US_Edit::isSet_to_edit_triple( QString triple_name, QString opsys )
 	  if ( wvl_set_edit == wvl )
 	    {
 	      qDebug() << "Triple " << triple_name << " for channel " <<  channel << " is set for EDIT.";
-	      have_run = true;	      
+	      have_run = true;
 	      break;
 	    }
 	}
     }
-  
+
   return have_run;
 }
 
@@ -10762,7 +10795,7 @@ QString US_Edit::compose_json( bool fm_stage )
     json += QString("\"2DSA_FM\",");
   if ( job3run )
     {
-      if ( job3auto ) 
+      if ( job3auto )
 	json += QString("\"FITMEN_AUTO\",");
       else
 	json += QString("\"FITMEN\",");
@@ -10773,12 +10806,12 @@ QString US_Edit::compose_json( bool fm_stage )
     json += QString("\"2DSA_MC\",");
   if (job6run_pcsa )
     json += QString("\"PCSA\",");
-  
+
   //remove last coma
   json.chop(1);
 
   json += QString("]}");
-  
+
   return json;
 }
 
@@ -10792,7 +10825,7 @@ void US_Edit::update_autoflow_record_atEditData_abde( US_DB2* db )
       << QString::number( autoflowID_passed );
 
   int status = db->statusQuery( qry );
-   
+
   if ( status == US_DB2::NO_AUTOFLOW_RECORD )
     {
       QMessageBox::warning( this,
@@ -10808,12 +10841,12 @@ void US_Edit::update_autoflow_record_atEditData( US_DB2* db,  QString& AnalysisI
 {
    QString runID_numeric     = details_at_editing_local[ "runID" ];
    QString OptimaName        = details_at_editing_local[ "OptimaName" ];
-   
+
    // // Check DB connection
    // US_Passwd pw;
    // QString masterpw = pw.getPasswd();
    // US_DB2* db = new US_DB2( masterpw );
-   
+
    // if ( db->lastErrno() != US_DB2::OK )
    //   {
    //     QMessageBox::warning( this, tr( "Connection Problem" ),
@@ -10832,11 +10865,11 @@ void US_Edit::update_autoflow_record_atEditData( US_DB2* db,  QString& AnalysisI
 
    qDebug() << "Updating Autoflow tables with analysisIDs!!!";
    qDebug() << "query: " << qry;
-   
+
    //db->query( qry );
 
    int status = db->statusQuery( qry );
-   
+
    if ( status == US_DB2::NO_AUTOFLOW_RECORD )
      {
        QMessageBox::warning( this,
@@ -10845,22 +10878,22 @@ void US_Edit::update_autoflow_record_atEditData( US_DB2* db,  QString& AnalysisI
 				 "associated with this experiment." ) );
        return;
      }
-   
+
 }
 
 
 // Function to create a single autoflowAnalysis record: Pass some fields from autoflow table (set analysises IDs, filename etc.)
-int US_Edit::create_autoflowAnalysis_record( US_DB2* db, QString& tripleName, QString& status_json ) 
+int US_Edit::create_autoflowAnalysis_record( US_DB2* db, QString& tripleName, QString& status_json )
 {
-  //create single record in autoflowAnalysis: return ID (auto-incremented), && update/push 
+  //create single record in autoflowAnalysis: return ID (auto-incremented), && update/push
 
   int autoflowAnalysisID = 0;
-   
+
   // // Check DB connection
   //  US_Passwd pw;
   //  QString masterpw = pw.getPasswd();
   //  US_DB2* db = new US_DB2( masterpw );
-   
+
   //  if ( db->lastErrno() != US_DB2::OK )
   //    {
   //      QMessageBox::warning( this, tr( "Connection Problem" ),
@@ -10879,11 +10912,11 @@ int US_Edit::create_autoflowAnalysis_record( US_DB2* db, QString& tripleName, QS
   int auto_incr = db->statusQuery( qry );
   qDebug() << "AutoflowAnalysis table: AUTO_INCREMENT: " << auto_incr;
 
-  //Now add autoflowAnalysis record 
+  //Now add autoflowAnalysis record
    QString status =  QString("Saving AutoflowAnalysis Profile for Triple %1").arg( tripleName );
    le_status->setText( status );
    qApp->processEvents();
-   
+
    qry.clear();
    qry << "new_autoflow_analysis_record"
        << tripleName
@@ -10892,25 +10925,25 @@ int US_Edit::create_autoflowAnalysis_record( US_DB2* db, QString& tripleName, QS
        << idInv_auto
        << status_json
        << QString::number( autoflowID_passed );
- 
+
    qDebug() << "AutoflowAnalysis Record for triple: " << tripleName;
    qDebug() << "Query: " << qry;
-   
+
    autoflowAnalysisID = db->functionQuery( qry );
 
    return autoflowAnalysisID;
-   
+
 }
 
 // Function to create a single autoflowAnalysisStages record:
-void US_Edit::create_autoflowAnalysisStages_record( US_DB2* db, int ID ) 
+void US_Edit::create_autoflowAnalysisStages_record( US_DB2* db, int ID )
 {
   QStringList qry;
   qry << "new_autoflow_analysis_stages_record"
       << QString::number( ID );
-  
+
   qDebug() << "Query: " << qry;
-  
+
   db->query( qry );
 }
 
@@ -10919,9 +10952,9 @@ void US_Edit::create_autoflowAnalysisStages_record( US_DB2* db, int ID )
 void US_Edit::write_triple_auto( int trx )
 {
    triple_index = trx;
-  
+
    index_data_auto( trx );
-  
+
    edata          = outData[ data_index ];
    data           = *edata;
 
@@ -10934,7 +10967,7 @@ void US_Edit::write_triple_auto( int trx )
 
    int     odax   = trx;
    int     idax   = odax;
-   
+
    // Base parameters for triple:
    QString triple_name = cb_triple->itemText( trx );
 
@@ -10943,7 +10976,7 @@ void US_Edit::write_triple_auto( int trx )
 
    scanExcl_begin_ind = editProfile_scans_excl[ triple_name ][0].toInt();
    scanExcl_end_ind   = editProfile_scans_excl[ triple_name ][1].toInt();
-   
+
    meniscus      = editProfile[ triple_name ][0].toDouble();
    range_left    = editProfile[ triple_name ][1].toDouble();
    range_right   = editProfile[ triple_name ][2].toDouble();
@@ -10964,17 +10997,17 @@ void US_Edit::write_triple_auto( int trx )
 	 }
        else
 	 wvl_c = triple_name.split("/")[2].trimmed();
-       
+
        bl_corr_slope      = editProfile_blc[ triple_name ][ wvl_c ][0].toDouble();
        bl_corr_yintercept = editProfile_blc[ triple_name ][ wvl_c ][1].toDouble();
      }
-  
+
    if ( dataType == "IP" )
      {
        airGap_left      = editProfile[ triple_name ][7].toDouble();
-       airGap_right     = editProfile[ triple_name ][8].toDouble(); 
+       airGap_right     = editProfile[ triple_name ][8].toDouble();
      }
-   
+
    if ( editProfile[ triple_name ].count() > 6 )
      {
        if ( editProfile[ triple_name ][6] == "spike_true")
@@ -10983,14 +11016,14 @@ void US_Edit::write_triple_auto( int trx )
 	 is_spike_auto = false;
      }
 
-   // ALEXEY: the bottom value affected by rotor stretch - time consuming !!! Do we need it ? 
+   // ALEXEY: the bottom value affected by rotor stretch - time consuming !!! Do we need it ?
    // US_SimulationParameters simparams;
    // simparams.initFromData( dbP, data, false, runID, dataType );
    // bottom         = simparams.bottom;
 
-   bottom = centerpieceParameters[ trx ][1].toDouble();  //Should be from centerpiece info from protocol 
+   bottom = centerpieceParameters[ trx ][1].toDouble();  //Should be from centerpiece info from protocol
    // End of base parameters
-   
+
 
    if ( isMwl )
    {  // For MultiWavelength, data index needs to be recomputed
@@ -11002,8 +11035,8 @@ void US_Edit::write_triple_auto( int trx )
    }
 
 
-   
-   
+
+
    // Do we need this ??
    /*
    if ( expIsEquil )
@@ -11014,7 +11047,7 @@ void US_Edit::write_triple_auto( int trx )
       range_right = sData[ jsd ].dataRight;
       baseline    = range_left;
       plateau     = range_right;
-   } 
+   }
    */
 
    // Check if complete
@@ -11075,7 +11108,7 @@ void US_Edit::write_triple_auto( int trx )
 
    if ( expType.isEmpty()  || expType.compare( "other", Qt::CaseInsensitive ) == 0 )
      expType = "Velocity";
-   
+
    editGUID         = editGUIDs[ idax ];
 
    if ( editGUID.isEmpty() )
@@ -11108,12 +11141,12 @@ void US_Edit::write_triple_auto( int trx )
 	       return;
 	     }
 	 }
-       
+
        editID           = editIDs[ idax ];
-       
+
        // Output the edit database record
        wrstat     = write_edit_db( dbP, filename, editGUID, editID, rawGUID );
-       
+
        if ( wrstat != 0 )
          return;
      }
@@ -11124,15 +11157,15 @@ void US_Edit::write_triple_auto( int trx )
    QString rptfname = "dsinfo." + tpart + ".dataset_info.html";
    QString rptfpath = QString( workingDir ).replace( "/results", "/reports" ) + rptfname;
    int     idEdit   = editID.toInt();
-   
+
    create_report_auto( rtext, trx );
-   
+
    save_report_auto( rtext, rptfpath, idEdit, trx );
 
    //Disconnect cb_triple if runType_combined_IP_RI == true;
    if ( runType_combined_IP_RI )
      cb_triple->disconnect();
-  
+
 }
 
 
@@ -11229,13 +11262,13 @@ DbgLv(1) << "BL: CC : baseline bl" << baseline << bl;
                "the Edit Label.<br/>"
                "Use alphanumeric characters or hyphens (no spaces).<br/>"
                "Enter 0 to 10 suffix characters." );
-      sufx   = QInputDialog::getText( this, 
+      sufx   = QInputDialog::getText( this,
          tr( "Create a unique session Edit Label" ),
          msg,
          QLineEdit::Normal,
          sufx,
          &ok );
-      
+
       if ( ! ok ) return;
 
 DbgLv(1) << "EDT:WrTripl: orig sufx" << sufx;
@@ -11271,7 +11304,7 @@ DbgLv(1) << "EDT:WrTripl:  rmvd sufx" << sufx;
    }
 
    // Determine file name
-   // workingDir + runID + editLabel + data type + cell + channel + wavelength 
+   // workingDir + runID + editLabel + data type + cell + channel + wavelength
    //            + ".xml"
 
    QString filename = files[ idax ];
@@ -11365,11 +11398,11 @@ DbgLv(1) << "AppPri: IN  dkdb" << disk_controls->db();
       }
 
       QStringList q( "get_rawDataID_from_GUID" );
-     
+
       q << US_Util::uuid_unparse( (uchar*)data.rawGUID );
       dbP->query( q );
 
-      // Error check    
+      // Error check
       if ( dbP->lastErrno() != US_DB2::OK )
       {
          QMessageBox::warning( this,
@@ -11378,7 +11411,7 @@ DbgLv(1) << "AppPri: IN  dkdb" << disk_controls->db();
 
          return;
       }
-      
+
       dbP->next();
       QString rawDataID = dbP->value( 0 ).toString();
 
@@ -11410,7 +11443,7 @@ DbgLv(1) << "AppPri: IN  dkdb" << disk_controls->db();
       US_GetEdit dialog( index, filenames );
       if ( dialog.exec() == QDialog::Rejected ) return;
 
-      if ( index >= 0 ) 
+      if ( index >= 0 )
       {
          filepath   = workingDir + filenames[ index ];
          int dataID = editDataIDs[ index ].toInt();
@@ -11425,15 +11458,15 @@ DbgLv(1) << "AppPri: IN  dkdb" << disk_controls->db();
       filter = "*" + filter.mid( index1 );
       filter.replace( QRegExp( "auc$" ), "xml" );
       filter = tr( "Edits(" ) + filter + tr( ");;All XML (*.xml)" );
-      
+
       // Ask for edit file
-      filepath = QFileDialog::getOpenFileName( this, 
+      filepath = QFileDialog::getOpenFileName( this,
             tr( "Select a saved edit file" ),
             workingDir, filter );
    }
 DbgLv(1) << "AppPri: fpath" << filepath;
 
-   if ( filepath.isEmpty() ) return; 
+   if ( filepath.isEmpty() ) return;
 
    // Get multiple edits if they exist and user so chooses
    QStringList editfiles;
@@ -11448,7 +11481,7 @@ DbgLv(1) << "AppPri: nledits" << nledits << editfiles.count();
 
    if ( nledits > 1 )
    {
-      QPushButton* pb_defb; 
+      QPushButton* pb_defb;
       QPushButton* pb_selo;
       QPushButton* pb_allw;
       QString edtLbl = editfiles[ 0 ].section( ".", -6, -6 );
@@ -11525,7 +11558,7 @@ DbgLv(1) << "AppPri: AllWavl button clicked";
    {
       QMessageBox::warning( this,
          tr( "XML Error" ),
-         tr( "An error occurred when reading edit file\n\n" ) 
+         tr( "An error occurred when reading edit file\n\n" )
          +  US_DataIO::errorString( result ) );
       return;
    }
@@ -11540,7 +11573,7 @@ DbgLv(1) << "AppPri: AllWavl button clicked";
 DbgLv(1) << "parsGUID rawGUID" << parameters.dataGUID << uuid;
       return;
    }
-   
+
    // Apply the edits with specified parameters
    apply_edits( parameters );
 
@@ -11578,12 +11611,12 @@ void US_Edit::prior_equil( void )
       }
 
       QStringList q( "get_rawDataID_from_GUID" );
-      
+
       q << US_Util::uuid_unparse( (uchar*)data.rawGUID );
 
       db.query( q );
 
-      // Error check    
+      // Error check
       if ( db.lastErrno() != US_DB2::OK )
       {
          QMessageBox::warning( this,
@@ -11592,7 +11625,7 @@ void US_Edit::prior_equil( void )
 
          return;
       }
-      
+
       db.next();
       QString rawDataID = db.value( 0 ).toString();
 
@@ -11641,7 +11674,7 @@ void US_Edit::prior_equil( void )
       {
          data    = *outData[ ii ];
          q.clear();
-         q << "get_rawDataID_from_GUID" 
+         q << "get_rawDataID_from_GUID"
            << US_Util::uuid_unparse( (uchar*)data.rawGUID );
          db.query( q );
          db.next();
@@ -11658,7 +11691,7 @@ void US_Edit::prior_equil( void )
             dataID      = db.value( 0 ).toString().toInt();
             filename    = db.value( 2 ).toString();
             QString elb = filename.section( ".", -6, -6 );
-            
+
             if ( elb == editLabel )
             {
                found = true;
@@ -11681,13 +11714,13 @@ void US_Edit::prior_equil( void )
 
       filter.insert( index1, "*." );
       filter.replace( QRegExp( "auc$" ), "xml" );
-      
+
       // Ask for edit file
-      filename = QFileDialog::getOpenFileName( this, 
+      filename = QFileDialog::getOpenFileName( this,
             tr( "Select a saved edit file" ),
             workingDir, filter );
 
-      if ( filename.isEmpty() ) return; 
+      if ( filename.isEmpty() ) return;
 
       filename         = filename.replace( "\\", "/" );
       editLabel        = filename.section( "/", -1, -1 ).section( ".", -6, -6 );
@@ -11722,7 +11755,7 @@ void US_Edit::prior_equil( void )
       {
          QMessageBox::warning( this,
                tr( "XML Error" ),
-               tr( "An error occurred when reading edit file\n\n" ) 
+               tr( "An error occurred when reading edit file\n\n" )
                +  US_DataIO::errorString( result ) );
          continue;
       }
@@ -11736,7 +11769,7 @@ void US_Edit::prior_equil( void )
                tr( "The edit file was not created using the current data" ) );
          continue;
       }
-   
+
       // Apply the edits
       QString wkstr;
 
@@ -11771,8 +11804,8 @@ void US_Edit::prior_equil( void )
       {
          US_DataIO::adjust_interference( data, parameters );
          US_DataIO::calc_integral      ( data, parameters );
-         le_airGap->setText( wkstr.sprintf( "%.3f - %.3f", 
-                  airGap_left, airGap_right ) ); 
+         le_airGap->setText( wkstr.sprintf( "%.3f - %.3f",
+                  airGap_left, airGap_right ) );
          pb_airGap->setIcon( check );
          pb_airGap->setEnabled( true );
       }
@@ -11785,10 +11818,10 @@ void US_Edit::prior_equil( void )
       pb_dataEnd  ->setEnabled( true );
       plateau      = range_right - _PLATEAU_OFFSET_;
       le_plateau  ->setText( QString::number( plateau,     'f', 8 ) );
-   
+
       // Invert
       invert = parameters.invert;
-   
+
       if ( invert == -1.0 ) pb_invert->setIcon( check );
       else                  pb_invert->setIcon( QIcon() );
 
@@ -11808,13 +11841,13 @@ void US_Edit::prior_equil( void )
          int    scan   = parameters.editedPoints[ i ].scan;
          int    index1 = (int)parameters.editedPoints[ i ].radius;
          double value  = parameters.editedPoints[ i ].value;
-      
+
          Edits e;
          e.scan = scan;
          e.changes << QPointF( index1, value );
-     
+
          changed_points << e;
-      
+
          data.scanData[ scan ].rvalues[ index1 ] = value;
       }
 
@@ -11824,14 +11857,14 @@ void US_Edit::prior_equil( void )
       pb_spikes->setIcon( QIcon() );
       pb_spikes->setEnabled( true );
       if ( spikes ) remove_spikes();
-   
+
       // Noise
       noise_order = parameters.noiseOrder;
       if ( noise_order > 0 )
       {
-         US_RiNoise::calc_residuals( data, includes, range_left, range_right, 
+         US_RiNoise::calc_residuals( data, includes, range_left, range_right,
                noise_order, residuals );
-      
+
          subtract_residuals();
       }
       else
@@ -11898,7 +11931,7 @@ void US_Edit::review_edits( void )
 void US_Edit::next_triple_auto( void )
 {
    pb_priorChan ->setEnabled( true );
-   
+
    int row = cb_triple->currentIndex() + 1;
    //row     = ( row < cb_triple->count() ) ? row : 0;
 
@@ -11906,26 +11939,26 @@ void US_Edit::next_triple_auto( void )
      {
        cb_triple->disconnect();
        cb_triple->setCurrentIndex( row );
-       connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+       connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
 		SLOT  ( new_triple_auto    ( int ) ) );
-       
+
        if ( le_edtrsp->isVisible() )
 	 {
 	   QString trsp = cb_triple->currentText() + " : " + trip_rpms[ 0 ];
 	   le_edtrsp->setText( trsp );
 	   cb_rpms  ->setCurrentIndex( 0 );
 	 }
-       
+
        int dax = index_data();
        //int dax = mwl_data.data_index( iwavl_edit_ref[ triple_index ], triple_index );
-       
+
        data    = *outData[ dax ];
-       
+
        new_triple_auto( dax );
-       
+
        if ( (row + 1 ) == cb_triple->count() )
          pb_nextChan ->setEnabled( false );
-       
+
        qDebug() << "NEXT Triple: row " << row << ", cb_triple->count() " << cb_triple->count() ;
    }
    else
@@ -11936,7 +11969,7 @@ void US_Edit::next_triple_auto( void )
 void US_Edit::prior_triple_auto( void )
 {
   pb_nextChan ->setEnabled( true );
-  
+
   int row = cb_triple->currentIndex() - 1;
   //row     = ( row < cb_triple->count() ) ? row : 0;
 
@@ -11944,32 +11977,32 @@ void US_Edit::prior_triple_auto( void )
     {
       cb_triple->disconnect();
       cb_triple->setCurrentIndex( row );
-      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+      connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
 	       SLOT  ( new_triple_auto    ( int ) ) );
-      
+
       // if ( le_edtrsp->isVisible() )
       // 	 {
       // 	   QString trsp = cb_triple->currentText() + " : " + trip_rpms[ 0 ];
       // 	   le_edtrsp->setText( trsp );
       // 	   cb_rpms  ->setCurrentIndex( 0 );
       // 	 }
-      
-      
+
+
       int dax = index_data();
       data    = *outData[ dax ];
-      
+
       new_triple_auto( dax );
 
       if ( row == 0 )
 	pb_priorChan ->setEnabled( false );
 
-      
+
       pb_nextChan ->setEnabled( true );
       qDebug() << "PRIOR Triple: row " << row << ", cb_triple->count() " << cb_triple->count() ;
     }
   else
     pb_priorChan ->setEnabled( false );
-  
+
 }
 
 
@@ -11981,7 +12014,7 @@ void US_Edit::next_triple( void )
 
    cb_triple->disconnect();
    cb_triple->setCurrentIndex( row );
-   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ), 
+   connect( cb_triple, SIGNAL( currentIndexChanged( int ) ),
                        SLOT  ( new_triple         ( int ) ) );
 
    if ( le_edtrsp->isVisible() )
@@ -12087,7 +12120,7 @@ void US_Edit::show_mwl_controls( bool show )
       pb_rarrow  ->setVisible( show );
       pb_custom  ->setVisible( show );
       pb_incall  ->setVisible( show );
-      
+
       lo_lrange  ->itemAtPosition( 0, 0 )->widget()->setVisible( show );
       lo_lrange  ->itemAtPosition( 0, 1 )->widget()->setVisible( show );
       lo_custom  ->itemAtPosition( 0, 0 )->widget()->setVisible( show );
@@ -12106,7 +12139,7 @@ void US_Edit::show_mwl_controls( bool show )
 	}
 
     }
-  
+
    adjustSize();
 }
 
@@ -12432,7 +12465,7 @@ void US_Edit::lambda_plot_value( int value )
 DbgLv(1) << "lambda_plot_value  value" << value << plotrec;
    QString fname    = ( menissv != 0.0 ) ? editFnames[ idax ] : "none";
 
-   //ALEXEY: 
+   //ALEXEY:
    if ( us_edit_auto_mode )
      {
        plot_mwl();
@@ -12442,14 +12475,14 @@ DbgLv(1) << "lambda_plot_value  value" << value << plotrec;
 	   set_current_bll_abde( cb_triple->currentText(), swavl );
 	   //then replot
 	   plot_range_and_blc( );
-	   
+
 	 }
        else
 	 plot_range();
        return;
      }
    ////////
-   
+
 
    if ( fname == "none" )
    {  // New wavelength has no edit:  turn off edits
@@ -12610,7 +12643,7 @@ DbgLv(1) << "od_radius_limit  value" << value;
 // Write edit to all wavelengths of the current cell/channel
 void US_Edit::write_mwl_auto( int trx )
 {
-  
+
   US_Passwd pw;
   US_DB2* dbP            = new US_DB2( pw.getPasswd() );
 
@@ -12626,10 +12659,10 @@ void US_Edit::write_mwl_auto( int trx )
   index_data_auto( trx );
 
   qDebug() << "[in WRITE-MWL-auto 1]";
-  
+
   edata          = outData[ data_index ];
   data           = *edata;
-  
+
   qDebug() << "[in WRITE-MWL-auto 2]";
 
   is_spike_auto = false;
@@ -12645,7 +12678,7 @@ void US_Edit::write_mwl_auto( int trx )
 				 "for MultiWavelength data. No Save will be performed." ) );
       return;
     }
-  
+
   // Base parameters for triple:
    QString triple_name = cb_triple->itemText( trx );
 
@@ -12654,7 +12687,7 @@ void US_Edit::write_mwl_auto( int trx )
 
    scanExcl_begin_ind = editProfile_scans_excl[ triple_name ][0].toInt();
    scanExcl_end_ind   = editProfile_scans_excl[ triple_name ][1].toInt();
-   
+
    meniscus      = editProfile[ triple_name ][0].toDouble();
    range_left    = editProfile[ triple_name ][1].toDouble();
    range_right   = editProfile[ triple_name ][2].toDouble();
@@ -12668,7 +12701,7 @@ void US_Edit::write_mwl_auto( int trx )
    //     bl_corr_slope      = editProfile_blc[ triple_name ][0].toDouble();
    //     bl_corr_yintercept = editProfile_blc[ triple_name ][1].toDouble();
    //   }
-   
+
    if ( editProfile[ triple_name ].count() > 6 )
      {
        if ( editProfile[ triple_name ][6] == "spike_true")
@@ -12677,9 +12710,9 @@ void US_Edit::write_mwl_auto( int trx )
 	 is_spike_auto = false;
      }
 
-   bottom = centerpieceParameters[ trx ][1].toDouble();  //Should be from centerpiece info from protocol 
+   bottom = centerpieceParameters[ trx ][1].toDouble();  //Should be from centerpiece info from protocol
    // End of base parameters
-   
+
    //Is this needed ?
    /*
    if ( expIsEquil )
@@ -12761,13 +12794,13 @@ void US_Edit::write_mwl_auto( int trx )
      {
        current_wvlns_list << QString::number( current_wvlns[ wvx ] );
      }
-   
-   QString celchn   = celchns.at( triple_index );                // ALEXEY: <-- is it  lopped over triple indecies? 
+
+   QString celchn   = celchns.at( triple_index );                // ALEXEY: <-- is it  lopped over triple indecies?
    QString scell    = celchn.section( "/", 0, 0 ).simplified();
    QString schan    = celchn.section( "/", 1, 1 ).simplified();
    QString tripbase = scell + " / " + schan + " / ";
-   int     idax     = triples.indexOf( tripbase + current_wvlns_list[ 0 ] ); 
-   //int     odax     = index_data_auto( trx, 0 );                             //CORRECT! {first odax in a triple}                                
+   int     idax     = triples.indexOf( tripbase + current_wvlns_list[ 0 ] );
+   //int     odax     = index_data_auto( trx, 0 );                             //CORRECT! {first odax in a triple}
 
    //qDebug() << "Write_MWL:  triple_index, #wvlns, odax, celchn" << triple_index << "," << curr_wvls_count << ", " << odax << "," << celchn;
 
@@ -12779,7 +12812,7 @@ void US_Edit::write_mwl_auto( int trx )
 
    QString filebase_qry   = files[ idax ].section( ".",  0, -6 );
    QString triplename_qry = scell + "." + schan + ".";
-   
+
    // Loop to output a file/db-record for each wavelength of the cell/channel
    for ( int wvx = 0; wvx < current_wvlns_list.size(); wvx++ )           //ALEXEY: needs to be looped over channels, not only current channel
    {
@@ -12789,7 +12822,7 @@ void US_Edit::write_mwl_auto( int trx )
       idax             = triples.indexOf( triple );
       //odax             = index_data_auto( trx, wvx );                             // Correct ? NOT!!! Got you !!
 
-      
+
       qDebug()  << "EDT:WrMwl:  wvx triple" << wvx << triple << "filename" << filename
 		<< ", trx " << trx << ", wvx " << wvx; // << ", odax " << odax;
 
@@ -12802,7 +12835,7 @@ void US_Edit::write_mwl_auto( int trx )
           bl_corr_yintercept = editProfile_blc[ triple_name ][ swavl ][1].toDouble();
         }
 
-      
+
       QString editGUID = editGUIDs[ idax ];
 
       if ( editGUID.isEmpty() )
@@ -12860,7 +12893,7 @@ DbgLv(1) << "EDT:WrMwl:  dax fname" << idax << filename << "wrstat" << wrstat;
       }  // END:  DB output
 
       //++odax;      //Got you!!
-      
+
    }  // END:  wavelength-in-cellchannel loop
 
    QApplication::restoreOverrideCursor();
@@ -12871,7 +12904,7 @@ DbgLv(1) << "EDT:WrMwl:  dax fname" << idax << filename << "wrstat" << wrstat;
    le_info->setText( saved_info );
    qApp->processEvents();
 
-   if ( runType_combined_IP_RI ) 
+   if ( runType_combined_IP_RI )
      cb_triple->disconnect();
 }
 
@@ -12881,12 +12914,12 @@ QString US_Edit::get_rawDataGUID( US_DB2* db, QString filebase_qry, QString trip
 
   QString rawID   = QString("");
   QString rawGUID = QString("");
-  
+
   QStringList qry;
   qry << "get_rawDataGUID_from_filename" << filebase_qry << triplename_qry;
   qDebug() << "get_rawDataGUID_from_filename QRY -- " << qry;
   db->query( qry );
-  
+
   while ( db->next() )
     {
       rawID   = db->value( 0 ).toString();
@@ -12964,13 +12997,13 @@ void US_Edit::write_mwl()
          + tr( "You may add an optional suffix to further distinquish<br/>"
                "the Edit Label. Use alphanumeric characters, underscores,<br/>"
                "or hyphens (no spaces). Enter 0 to 10 suffix characters." );
-      sufx         = QInputDialog::getText( this, 
+      sufx         = QInputDialog::getText( this,
          tr( "Create a unique session Edit Label" ),
          msg,
          QLineEdit::Normal,
          sufx,
          &ok );
-      
+
       if ( ! ok ) return;
 
       sufx.remove( QRegExp( "[^\\w\\d_-]" ) );
@@ -13163,7 +13196,7 @@ DbgLv(1) << "EDT:WrXml:  waveln" << waveln;
    if ( us_edit_auto_mode )  //<-- write excluded scans (beg|end) based on AProfile
      {
         xml.writeStartElement( "excludes" );
-	
+
 	//beginning of the scan set
 	for ( int ii = 0; ii < scanExcl_begin_ind; ii++ )
 	  {
@@ -13181,10 +13214,10 @@ DbgLv(1) << "EDT:WrXml:  waveln" << waveln;
 	  }
 
 
-	//Also, for ABDE, exclude what was excluded manually for each triple 
+	//Also, for ABDE, exclude what was excluded manually for each triple
 	for ( int ii = 0; ii < data.scanData.size(); ii++ )
 	  {
-	    if ( ! includes.contains( ii ) && 
+	    if ( ! includes.contains( ii ) &&
 		 ii >= scanExcl_begin_ind   &&
 		 ii < data.scanData.size() - scanExcl_end_ind )
 	      {
@@ -13193,7 +13226,7 @@ DbgLv(1) << "EDT:WrXml:  waveln" << waveln;
 		xml.writeEndElement  ();
 	      }
 	  }
-	
+
 	xml.writeEndElement  ();  // excludes
      }
    else
@@ -13201,7 +13234,7 @@ DbgLv(1) << "EDT:WrXml:  waveln" << waveln;
        if ( data.scanData.size() > includes.size() )
 	 {
 	   xml.writeStartElement( "excludes" );
-	   
+
 	   for ( int ii = 0; ii < data.scanData.size(); ii++ )
 	     {
 	       if ( ! includes.contains( ii ) )
@@ -13211,7 +13244,7 @@ DbgLv(1) << "EDT:WrXml:  waveln" << waveln;
 		   xml.writeEndElement  ();
 		 }
 	     }
-	 
+
 	   xml.writeEndElement  ();  // excludes
 	 }
      }
@@ -13343,7 +13376,7 @@ DbgLv(1) << "EDT:WrXml:  waveln" << waveln;
          xml.writeEndElement  ();  // speed
       }
    }
- 
+
    xml.writeEndElement  ();  // parameters
 
    if ( ! pb_residuals->icon().isNull()  ||
@@ -13353,7 +13386,7 @@ DbgLv(1) << "EDT:WrXml:  waveln" << waveln;
 	is_spike_auto                     )
    {
       xml.writeStartElement( "operations" );
- 
+
       // Write RI Noise
       if ( ! pb_residuals->icon().isNull() )
       {
@@ -13425,7 +13458,7 @@ int US_Edit::write_edit_db( US_DB2* dbP, QString& fname, QString& editGUID,
 
    if ( dbP->lastErrno() != US_DB2::OK )
    {
-      QMessageBox::warning( this, 
+      QMessageBox::warning( this,
          tr( "AUC Data is not in DB" ),
          tr( "Cannot save edit data to the database.\n"
              "The associated AUC data is not present." ) );
@@ -13449,7 +13482,7 @@ int US_Edit::write_edit_db( US_DB2* dbP, QString& fname, QString& editGUID,
       if ( dbP->lastErrno() != US_DB2::OK )
       {
          QMessageBox::warning( this, tr( "Database Problem" ),
-            tr( "Could not insert metadata into the database\n" ) + 
+            tr( "Could not insert metadata into the database\n" ) +
                 dbP->lastError() );
 
          return 3;
@@ -13470,7 +13503,7 @@ int US_Edit::write_edit_db( US_DB2* dbP, QString& fname, QString& editGUID,
       if ( dbP->lastErrno() != US_DB2::OK )
       {
          QMessageBox::warning( this, tr( "Database Problem" ),
-            tr( "Could not update metadata in the database \n" ) + 
+            tr( "Could not update metadata in the database \n" ) +
             dbP->lastError() );
 
          return 4;
@@ -13484,7 +13517,7 @@ int US_Edit::write_edit_db( US_DB2* dbP, QString& fname, QString& editGUID,
    if ( dbP->lastErrno() != US_DB2::OK )
    {
       QMessageBox::warning( this, tr( "Database Problem" ),
-         tr( "Could not insert edit xml data into database \n" ) + 
+         tr( "Could not insert edit xml data into database \n" ) +
          dbP->lastError() );
       return 5;
    }
@@ -13505,7 +13538,7 @@ int US_Edit::index_data_auto( int trx, int wvx )
    //Debug
    for ( int g=0; g < expi_wvlns.size(); ++g )
      qDebug() << "MWL wavelengths for triple: " << triple_name << expi_wvlns[ g ];
-   
+
    if ( isMwl )
    {  // For MWL, compute data index from wavelength and triple indexes
       if ( wvx < 0 )
@@ -13513,7 +13546,7 @@ int US_Edit::index_data_auto( int trx, int wvx )
          plotndx      = cb_lplot->currentIndex();
          int iwavl    = expi_wvlns[ plotndx ];              //ALEXEY: do we need to set data in the middle of the triple set ??
 
-	 //int iwavl    = expi_wvlns[ 0 ];                      // ALEXEY: OR beginning of the set? ??   
+	 //int iwavl    = expi_wvlns[ 0 ];                      // ALEXEY: OR beginning of the set? ??
 	 data_index   = mwl_data.data_index( iwavl, triple_index );
          odatx        = data_index;
 DbgLv(1) << "IxDa_AUTO: dx" << data_index << "plx wavl trx"
@@ -13690,8 +13723,8 @@ int US_Edit::apply_edits( US_DataIO::EditValues parameters )
    {
       US_DataIO::adjust_interference( data, parameters );
       US_DataIO::calc_integral      ( data, parameters );
-      le_airGap->setText( wkstr.sprintf( "%.3f - %.3f", 
-               airGap_left, airGap_right ) ); 
+      le_airGap->setText( wkstr.sprintf( "%.3f - %.3f",
+               airGap_left, airGap_right ) );
       pb_airGap->setIcon( check );
       pb_airGap->setEnabled( true );
    }
@@ -13700,7 +13733,7 @@ int US_Edit::apply_edits( US_DataIO::EditValues parameters )
    le_dataEnd  ->setText( QString::number( range_right, 'f', 8 ) );
    pb_dataEnd  ->setIcon( check );
    pb_dataEnd  ->setEnabled( true );
-   
+
    plateau      = range_right - _PLATEAU_OFFSET_;
    le_plateau  ->setText( QString::number( plateau,     'f', 8 ) );
 
@@ -13718,7 +13751,7 @@ DbgLv(1) << "BL: DD : baseline bl" << baseline << bl;
 
    // Invert
    invert = parameters.invert;
-   
+
    if ( invert == -1.0 ) pb_invert->setIcon( check );
    else                  pb_invert->setIcon( QIcon() );
 
@@ -13738,13 +13771,13 @@ DbgLv(1) << "BL: DD : baseline bl" << baseline << bl;
       int    scan   = parameters.editedPoints[ ii ].scan;
       int    index1 = (int)parameters.editedPoints[ ii ].radius;
       double value  = parameters.editedPoints[ ii ].value;
-      
+
       Edits e;
       e.scan = scan;
       e.changes << QPointF( index1, value );
-     
+
       changed_points << e;
-      
+
       data.scanData[ scan ].rvalues[ index1 ] = value;
    }
 
@@ -13754,14 +13787,14 @@ DbgLv(1) << "BL: DD : baseline bl" << baseline << bl;
    pb_spikes->setIcon( QIcon() );
    pb_spikes->setEnabled( true );
    if ( spikes ) remove_spikes();
-   
+
    // Noise
    noise_order = parameters.noiseOrder;
    if ( noise_order > 0 )
    {
-      US_RiNoise::calc_residuals( data, includes, range_left, range_right, 
+      US_RiNoise::calc_residuals( data, includes, range_left, range_right,
             noise_order, residuals );
-      
+
       subtract_residuals();
    }
    else
@@ -13802,7 +13835,7 @@ DbgLv(1) << "rsoD: aDa size" << allData.size() << "ncelchn" << ncelchn;
    for ( int ccx = 0; ccx < ncelchn; ccx++ )
    {
       lambdas_by_cell( ccx );
-       
+
       int kwvln   = mwl_data.lambdas( ex_wvlns, ccx );
       std::sort(ex_wvlns.begin(), ex_wvlns.end());
 DbgLv(1) << "rsoD: ccx kwv" << ccx << kwvln << ex_wvlns.size()
@@ -14013,7 +14046,7 @@ QString US_Edit::table_row( const QString s1, const QString s2 )
 }
 
 // Table row HTML with 3 columns
-QString US_Edit::table_row( const QString s1, const QString s2, 
+QString US_Edit::table_row( const QString s1, const QString s2,
                             const QString s3 )
 {
    return ( indent( 6 ) + "<tr><td>" + s1 + "</td><td>" + s2 + "</td><td>"
@@ -14021,8 +14054,8 @@ QString US_Edit::table_row( const QString s1, const QString s2,
 }
 
 // Table row HTML with 5 columns
-QString US_Edit::table_row( const QString s1, const QString s2, 
-                            const QString s3, const QString s4, 
+QString US_Edit::table_row( const QString s1, const QString s2,
+                            const QString s3, const QString s4,
                             const QString s5 )
 {
    return ( indent( 6 ) + "<tr><td>" + s1 + "</td><td>" + s2 + "</td><td>"
@@ -14030,8 +14063,8 @@ QString US_Edit::table_row( const QString s1, const QString s2,
 }
 
 // Table row HTML with 6 columns
-QString US_Edit::table_row( const QString s1, const QString s2, 
-                            const QString s3, const QString s4, 
+QString US_Edit::table_row( const QString s1, const QString s2,
+                            const QString s3, const QString s4,
                             const QString s5, const QString s6 )
 {
    return ( indent( 6 ) + "<tr><td>" + s1 + "</td><td>" + s2 + "</td><td>"
@@ -14041,7 +14074,7 @@ QString US_Edit::table_row( const QString s1, const QString s2,
 
 // Compose HTML header string
 QString US_Edit::html_header( const QString title, const QString head1 )
-{ 
+{
    int         trx     = index_data();
    QString     triple  = triples.at( trx );
    QStringList parts   = triple.split( " / " );
@@ -14050,7 +14083,7 @@ QString US_Edit::html_header( const QString title, const QString head1 )
    QString     wvlen   = parts[ 2 ];
    QString     editID  = editIDs[ trx ];
    QString     editLbl = editLabel.isEmpty() ?
-                         editFnames[ trx ].section( ".", -6, -6 ) : 
+                         editFnames[ trx ].section( ".", -6, -6 ) :
                          editLabel;
 
    QString ss = QString( "<?xml version=\"1.0\"?>\n" );
@@ -14075,13 +14108,13 @@ QString US_Edit::html_header( const QString title, const QString head1 )
    ss  += tr( ", Wavelength " ) + wvlen;
    ss  += ",<br/>\n" + indent( 4 ) + "&nbsp;" + tr( " Edited Dataset " );
    ss  += editLbl + "</h2>\n";
- 
+
    return ss;
 }
 
 // Compose HTML header string
 QString US_Edit::html_header_auto( const QString title, const QString head1, const int trx_curr )
-{ 
+{
    int         trx     = index_data_auto( trx_curr );
    QString     triple  = triples.at( trx );
    QStringList parts   = triple.split( " / " );
@@ -14090,7 +14123,7 @@ QString US_Edit::html_header_auto( const QString title, const QString head1, con
    QString     wvlen   = parts[ 2 ];
    QString     editID  = editIDs[ trx ];
    QString     editLbl = editLabel.isEmpty() ?
-                         editFnames[ trx ].section( ".", -6, -6 ) : 
+                         editFnames[ trx ].section( ".", -6, -6 ) :
                          editLabel;
 
    QString ss = QString( "<?xml version=\"1.0\"?>\n" );
@@ -14115,14 +14148,14 @@ QString US_Edit::html_header_auto( const QString title, const QString head1, con
    ss  += tr( ", Wavelength " ) + wvlen;
    ss  += ",<br/>\n" + indent( 4 ) + "&nbsp;" + tr( " Edited Dataset " );
    ss  += editLbl + "</h2>\n";
- 
+
    return ss;
 }
 
 QString US_Edit::run_details( void )
 {
    US_DataIO::RawData* dd = outData[ index_data() ];
-  
+
    int scsize = dd->scanData.size();
    // Temperature and raw speed data
    double sumte   =  0.0;
@@ -14152,8 +14185,8 @@ QString US_Edit::run_details( void )
    if ( maxTemp - minTemp <= US_Settings::tempTolerance() )
       ss += table_row( tr( "Temperature Variation:" ),
                        tr( "Within tolerance" ) );
-   else 
-      ss += table_row( tr( "Temperature Variation:" ), 
+   else
+      ss += table_row( tr( "Temperature Variation:" ),
                        tr( "(!) OUTSIDE TOLERANCE (!)" ) );
 
    // Time data
@@ -14164,7 +14197,7 @@ QString US_Edit::run_details( void )
    QString mm  = ( minutes == 1 ) ? tr( " minute " ) : tr( " minutes " );
    QString sec = ( seconds == 1 ) ? tr( " second"  ) : tr( " seconds"  );
 
-   ss += table_row( tr( "Time Correction:" ), 
+   ss += table_row( tr( "Time Correction:" ),
                     QString::number( minutes ) + mm +
                     QString::number( seconds ) + sec );
 
@@ -14186,8 +14219,8 @@ QString US_Edit::run_details( void )
    sec = ( seconds == 1 ) ? tr( " second"  ) : tr( " seconds" );
 
    ss += table_row( tr( "Run Duration:" ),
-                   QString::number( hours   ) + hh + 
-                   QString::number( minutes ) + mm + 
+                   QString::number( hours   ) + hh +
+                   QString::number( minutes ) + mm +
                    QString::number( seconds ) + sec );
 
    // Wavelength, baseline, meniscus, range
@@ -14199,7 +14232,7 @@ QString US_Edit::run_details( void )
    QString plat    = le_plateau->text();
 
    ss += table_row( tr( "Wavelength:" ),
-                    QString::number( iwvln ) + " nm" ) + 
+                    QString::number( iwvln ) + " nm" ) +
          table_row( tr( "Baseline " ) + dataType, bln_od );
          table_row( tr( "Meniscus Position:" ),
                     le_meniscus->text() + " cm" );
@@ -14207,7 +14240,7 @@ QString US_Edit::run_details( void )
 
    ss += table_row( tr( "Edited Data starts at:"  ), left + " cm" ) +
          table_row( tr( "Edited Data stops at:"   ), right + " cm " ) +
-         table_row( tr( "Plateau Position:"   ), plat + " cm" ); 
+         table_row( tr( "Plateau Position:"   ), plat + " cm" );
 
    ss += indent( 4 ) + "</table>\n";
 
@@ -14217,7 +14250,7 @@ QString US_Edit::run_details( void )
 QString US_Edit::run_details_auto( int trx )
 {
    US_DataIO::RawData* dd = outData[ index_data_auto( trx ) ];
-  
+
    int scsize = dd->scanData.size();
    // Temperature and raw speed data
    double sumte   =  0.0;
@@ -14247,8 +14280,8 @@ QString US_Edit::run_details_auto( int trx )
    if ( maxTemp - minTemp <= US_Settings::tempTolerance() )
       ss += table_row( tr( "Temperature Variation:" ),
                        tr( "Within tolerance" ) );
-   else 
-      ss += table_row( tr( "Temperature Variation:" ), 
+   else
+      ss += table_row( tr( "Temperature Variation:" ),
                        tr( "(!) OUTSIDE TOLERANCE (!)" ) );
 
    // Time data
@@ -14259,7 +14292,7 @@ QString US_Edit::run_details_auto( int trx )
    QString mm  = ( minutes == 1 ) ? tr( " minute " ) : tr( " minutes " );
    QString sec = ( seconds == 1 ) ? tr( " second"  ) : tr( " seconds"  );
 
-   ss += table_row( tr( "Time Correction:" ), 
+   ss += table_row( tr( "Time Correction:" ),
                     QString::number( minutes ) + mm +
                     QString::number( seconds ) + sec );
 
@@ -14281,8 +14314,8 @@ QString US_Edit::run_details_auto( int trx )
    sec = ( seconds == 1 ) ? tr( " second"  ) : tr( " seconds" );
 
    ss += table_row( tr( "Run Duration:" ),
-                   QString::number( hours   ) + hh + 
-                   QString::number( minutes ) + mm + 
+                   QString::number( hours   ) + hh +
+                   QString::number( minutes ) + mm +
                    QString::number( seconds ) + sec );
 
    // Wavelength, baseline, meniscus, range
@@ -14296,22 +14329,22 @@ QString US_Edit::run_details_auto( int trx )
 
    // Base parameters:
    QString triple_name_r = cb_triple->itemText( trx );
-      
+
    QString meniscus_r      = editProfile[ triple_name_r ][0];
    QString range_left_r    = editProfile[ triple_name_r ][1];
    QString range_right_r   = editProfile[ triple_name_r ][2];
    QString plateau_r       = editProfile[ triple_name_r ][3];
    QString baseline_r      = editProfile[ triple_name_r ][4];
    QString baseline_od_r   = editProfile[ triple_name_r ][5];
-   
+
    QString bln_od  = QString( baseline_od_r ) + " OD";
    QString left    = range_left_r ;
    QString right   = range_right_r;
    QString plat    = plateau_r;
-   
-   
+
+
    ss += table_row( tr( "Wavelength:" ),
-                    QString::number( iwvln ) + " nm" ) + 
+                    QString::number( iwvln ) + " nm" ) +
          table_row( tr( "Baseline " ) + dataType, bln_od ) +
          table_row( tr( "Meniscus Position:" ),
                     meniscus_r + " cm" );
@@ -14319,7 +14352,7 @@ QString US_Edit::run_details_auto( int trx )
 
    ss += table_row( tr( "Edited Data starts at:"  ), left + " cm" ) +
          table_row( tr( "Edited Data stops at:"   ), right + " cm " ) +
-         table_row( tr( "Plateau Position:"   ), plat + " cm" ); 
+         table_row( tr( "Plateau Position:"   ), plat + " cm" );
 
    ss += indent( 4 ) + "</table>\n";
 
@@ -14333,9 +14366,9 @@ QString US_Edit::scan_info( void )
    double time_correction  = US_Math2::time_correction( allData );
 
    QString ss = "\n" + indent( 4 ) + tr( "<h3>Scan Information:</h3>\n" )
-               + indent( 4 ) + "<table>\n"; 
-         
-   ss += table_row( tr( "Scan" ), tr( "Corrected Time" ), 
+               + indent( 4 ) + "<table>\n";
+
+   ss += table_row( tr( "Scan" ), tr( "Corrected Time" ),
                    tr( "Plateau Concentration" ),
                    tr( "Seconds" ), tr( "Omega^2T" ), tr( "Raw Speed" ) );
 
@@ -14351,13 +14384,13 @@ QString US_Edit::scan_info( void )
       double time  = dd->scanData[ ii ].seconds;
       double omg2t = dd->scanData[ ii ].omega2t;
       double speed = dd->scanData[ ii ].rpm;
-      int    ctime = (int)( dd->scanData[ ii ].seconds - time_correction ); 
+      int    ctime = (int)( dd->scanData[ ii ].seconds - time_correction );
       int    platx = US_DataIO::index( dd->xvalues, plateau );
       double od    = dd->scanData[ ii ].rvalues[ platx ];
 
       s1 = s1.sprintf( "%4d",             ii + 1 );
       s2 = s2.sprintf( "%4d min %2d sec", ctime / 60, ctime % 60 );
-      s3 = s3.sprintf( "%.6f OD",         od ); 
+      s3 = s3.sprintf( "%.6f OD",         od );
       s4 = s4.sprintf( "%5d",             (int)time );
       s5 = s5.sprintf( "%.5e",            omg2t );
       s6 = s6.sprintf( "%.1f",            speed );
@@ -14366,7 +14399,7 @@ QString US_Edit::scan_info( void )
    }
 
    ss += indent( 4 ) + "</table>\n";
-   
+
    return ss;
 }
 
@@ -14376,9 +14409,9 @@ QString US_Edit::scan_info_auto( int trx )
    double time_correction  = US_Math2::time_correction( allData );
 
    QString ss = "\n" + indent( 4 ) + tr( "<h3>Scan Information:</h3>\n" )
-               + indent( 4 ) + "<table>\n"; 
-         
-   ss += table_row( tr( "Scan" ), tr( "Corrected Time" ), 
+               + indent( 4 ) + "<table>\n";
+
+   ss += table_row( tr( "Scan" ), tr( "Corrected Time" ),
                    tr( "Plateau Concentration" ),
                    tr( "Seconds" ), tr( "Omega^2T" ), tr( "Raw Speed" ) );
 
@@ -14394,13 +14427,13 @@ QString US_Edit::scan_info_auto( int trx )
       double time  = dd->scanData[ ii ].seconds;
       double omg2t = dd->scanData[ ii ].omega2t;
       double speed = dd->scanData[ ii ].rpm;
-      int    ctime = (int)( dd->scanData[ ii ].seconds - time_correction ); 
+      int    ctime = (int)( dd->scanData[ ii ].seconds - time_correction );
       int    platx = US_DataIO::index( dd->xvalues, plateau );
       double od    = dd->scanData[ ii ].rvalues[ platx ];
 
       s1 = s1.sprintf( "%4d",             ii + 1 );
       s2 = s2.sprintf( "%4d min %2d sec", ctime / 60, ctime % 60 );
-      s3 = s3.sprintf( "%.6f OD",         od ); 
+      s3 = s3.sprintf( "%.6f OD",         od );
       s4 = s4.sprintf( "%5d",             (int)time );
       s5 = s5.sprintf( "%.5e",            omg2t );
       s6 = s6.sprintf( "%.1f",            speed );
@@ -14409,7 +14442,7 @@ QString US_Edit::scan_info_auto( int trx )
    }
 
    ss += indent( 4 ) + "</table>\n";
-   
+
    return ss;
 }
 
@@ -14432,7 +14465,7 @@ void US_Edit::pass_values_bll( void )
 					     "Do you want to proceed? " ),
 					 tr( "&OK" ), tr( "&Cancel" ),
 					 0, 0, 1 );
-  
+
   if ( status != 0 ) return;
 
    emit pass_edit_params_blc( editProfile_triple_blc );
@@ -14446,7 +14479,7 @@ void US_Edit::pass_values( void )
   //collect menicsus | airGap | baseline | range | etc data && pass to main edit stage
 
   QString triple_name = cb_triple->itemText( cb_triple->currentIndex() );
-  
+
   QMap< QString, QStringList > editProfile_triple;
   QMap< QString, QList<int> >  editProfile_triple_includes;
   QMap< QString, QStringList > editProfile_triple_blc;
@@ -14454,7 +14487,7 @@ void US_Edit::pass_values( void )
   //make sure all principal params account for possible manual field edit:
   meniscus     = le_meniscus->text().toDouble();
   range_right  = le_dataEnd->text().toDouble();
-  
+
   QStringList triple_params, triple_params_blc;
   triple_params <<  QString::number(meniscus)
 		<<  QString::number(range_left)
@@ -14473,34 +14506,34 @@ void US_Edit::pass_values( void )
       triple_params <<  QString::number(airGap_left)
 		    <<  QString::number(airGap_right);
     }
-  
+
   editProfile_triple[ triple_name ]          = triple_params;
   editProfile_triple_includes[ triple_name ] = includes;
   editProfile_triple_blc[ triple_name ]      = triple_params_blc;
-  
+
   qDebug() << "In PASSING values manually: triple_name, parms -- " << triple_name << editProfile_triple[ triple_name ];
   qDebug() << "In PASSING values manually: includes -- " << triple_name << editProfile_triple_includes[ triple_name ];
   qDebug() << "In PASSING values manually: linear-baseline-corr -- " << triple_name << editProfile_triple_blc[ triple_name ];
   qDebug() << "In PASSING values manually: us_edit_auto_mode BEFORE -- " << triple_name << us_edit_auto_mode;
-  
+
   int status = QMessageBox::information( this,
 					 tr( "New Edit Parameters" ),
 					 tr( "This will overwrite current edit parameters. "
 					     "Do you want to proceed? " ),
 					 tr( "&OK" ), tr( "&Cancel" ),
 					 0, 0, 1 );
-  
+
   if ( status != 0 ) return;
 
   emit pass_edit_params_includes( editProfile_triple_includes );
   emit pass_edit_params_blc( editProfile_triple_blc );
   emit pass_edit_params( editProfile_triple );
-    
+
   close();
 }
 
 //
-void US_Edit::close_manual_edit( void ) 
+void US_Edit::close_manual_edit( void )
 {
   emit restore_main_view();
   close();
@@ -14561,12 +14594,12 @@ void US_Edit::close_edit( void )
 
 // void US_Edit::resizeEvent(QResizeEvent *event)
 // {
-//   qDebug() << "US_EDIT resizing1..."; 
+//   qDebug() << "US_EDIT resizing1...";
 //   int offset = 20;
 //   int new_main_w = this->width() - 3*offset;
 //   int new_main_h = this->height() - 4*offset;
 //   qDebug() << "US_EDIT resizing2...";
-  
+
 //   if ( sdiag != NULL )
 //     {
 //       qDebug() << "Resizing sdiag...";
@@ -14574,23 +14607,23 @@ void US_Edit::close_edit( void )
 //       if ( new_main_w > sdiag->width() || new_main_h > sdiag->height()) {
 // 	int newWidth = qMax( new_main_w, sdiag->width());
 // 	int newHeight = qMax( new_main_h, sdiag->height());
-	
+
 // 	sdiag->setMaximumSize( newWidth, newHeight );
 // 	sdiag->resize( QSize(newWidth, newHeight) );
 // 	update();
 //       }
-      
+
 //       //if (mainw->width() < sdiag->width() || mainw->height() < sdiag->height()) {
 //       if ( new_main_w < sdiag->width() ||  new_main_h < sdiag->height() ) {
 // 	int newWidth = qMin( new_main_w, sdiag->width());
 // 	int newHeight = qMin( new_main_h, sdiag->height());
-	
+
 // 	sdiag->setMaximumSize( newWidth, newHeight );
 // 	sdiag->resize( QSize(newWidth, newHeight) );
 // 	update();
 //       }
 //     }
-  
+
 //   QWidget::resizeEvent(event);
 // }
 


### PR DESCRIPTION

### Additions to the `US_Edit` class:

* Added new buttons for baseline correction functionality, including "Remove All but Last," "Correct Baseline," "Modify Baseline Correction for Selected Triple," and "Accept Changes for a Channel." These buttons provide user interaction for managing and modifying baseline corrections. [[1]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8L48-R56) [[2]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8L796-R812) [[3]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8L1354-R1378) [[4]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8R1972-R1980)
* Introduced labels and line edits for displaying and editing baseline correction parameters, such as slope and Y-intercept. These UI elements are part of the linear baseline correction feature. [[1]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8L48-R56) [[2]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8L796-R812) [[3]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8L1354-R1378) [[4]](diffhunk://#diff-bc9b51794d4e844de36b755763d8754ea2c4adaea4eb72b30df1625f44ac25c8R1972-R1980)