### PR TITLE
Simulate constant baseline offset in us_astfem_sim

### DIFF
--- a/gui/us_sim_params_gui.cpp
+++ b/gui/us_sim_params_gui.cpp
@@ -351,6 +351,20 @@ US_SimParamsGui::US_SimParamsGui(
    main->addWidget( cnt_rinoise, row++, 7, 1, 1 );
    connect( cnt_rinoise, SIGNAL( valueChanged  ( double ) ), 
                          SLOT  ( update_rinoise( double ) ) );
+   
+   // constant baseline offset
+   QLabel* lb_baseline = us_label( tr( "Constant Baseline (Conc.):" ) );
+   main->addWidget( lb_baseline, row, 4, 1, 3 );
+
+   cnt_baseline = us_counter( 3, -10, 10, simparams.baseline );
+   cnt_baseline->setSingleStep    ( 0.01 );
+   cnt_baseline->setIncSteps( QwtCounter::Button1,   1 );
+   cnt_baseline->setIncSteps( QwtCounter::Button2,  10 );
+   cnt_baseline->setIncSteps( QwtCounter::Button3, 100 );
+
+   main->addWidget( cnt_baseline, row++, 7, 1, 1 );
+   connect( cnt_baseline, SIGNAL( valueChanged  ( double ) ), 
+                         SLOT  ( update_baseline( double ) ) );
   
    // Temperature
    QLabel* lb_temperature  = us_label( tr( "Temperature (%1):" )
@@ -489,6 +503,7 @@ void US_SimParamsGui::backup_parms( void )
    simparams_backup.rnoise            = simparams.rnoise;
    simparams_backup.tinoise           = simparams.tinoise;
    simparams_backup.rinoise           = simparams.rinoise;
+   simparams_backup.baseline          = simparams.baseline;
 }
 
 void US_SimParamsGui::revert( void )
@@ -524,6 +539,7 @@ void US_SimParamsGui::revert( void )
    simparams.lrnoise           = simparams_backup.lrnoise;
    simparams.tinoise           = simparams_backup.tinoise;
    simparams.rinoise           = simparams_backup.rinoise;
+   simparams.baseline          = simparams_backup.baseline;
    simparams.bottom_position   = simparams_backup.bottom_position;
 DbgLv(1) << "SPG: revert==";
 if(dbg_level>0)
@@ -920,6 +936,7 @@ void US_SimParamsGui::load( void )
       cnt_lrnoise         ->setValue( simparams.lrnoise           );
       cnt_tinoise         ->setValue( simparams.tinoise           );
       cnt_rinoise         ->setValue( simparams.rinoise           );
+      cnt_baseline        ->setValue( simparams.baseline          );
       cnt_temperature     ->setValue( simparams.temperature       );
 
       cmb_mesh            ->setCurrentIndex( (int)simparams.meshType );
@@ -1098,6 +1115,12 @@ void US_SimParamsGui::update_rinoise       ( double rinoise )
    report_mods();
 }
       
+void US_SimParamsGui::update_baseline       ( double baseline )
+{
+   simparams.baseline   = baseline;
+   report_mods();
+}
+      
 void US_SimParamsGui::update_moving        ( int grid )
 {
    simparams.gridType  = (US_SimulationParameters::GridType) grid;
@@ -1139,6 +1162,7 @@ void US_SimParamsGui::disconnect_all( )
    cnt_lrnoise         ->disconnect();
    cnt_tinoise         ->disconnect();
    cnt_rinoise         ->disconnect();
+   cnt_baseline        ->disconnect();
    cmb_mesh            ->disconnect();
    cmb_moving          ->disconnect();
 }
@@ -1185,6 +1209,8 @@ void US_SimParamsGui::reconnect_all( )
                                   SLOT  ( update_tinoise(        double ) ) );
    connect( cnt_rinoise,          SIGNAL( valueChanged  (        double ) ), 
                                   SLOT  ( update_rinoise(        double ) ) );
+   connect( cnt_baseline,         SIGNAL( valueChanged  (        double ) ), 
+                                  SLOT  ( update_baseline(       double ) ) );
    connect( cmb_mesh,             SIGNAL( activated  (           int ) ), 
                                   SLOT  ( update_mesh(           int ) ) );
    connect( cmb_moving,           SIGNAL( activated    (         int ) ), 

--- a/gui/us_sim_params_gui.h
+++ b/gui/us_sim_params_gui.h
@@ -55,6 +55,7 @@ class US_GUI_EXTERN US_SimParamsGui : public US_WidgetsDialog
       QwtCounter*   cnt_lrnoise;
       QwtCounter*   cnt_tinoise;
       QwtCounter*   cnt_rinoise;
+      QwtCounter*   cnt_baseline;
       QwtCounter*   cnt_temperature;
                    
       QCheckBox*    cb_acceleration_flag;
@@ -98,6 +99,7 @@ class US_GUI_EXTERN US_SimParamsGui : public US_WidgetsDialog
       void update_lrnoise       ( double lrnoise );
       void update_tinoise       ( double tinoise );
       void update_rinoise       ( double rinoise );
+      void update_baseline      ( double baseline );
       void update_moving        ( int grid );
       void select_centerpiece   ( bool );
       void update_temp          ( double temp );

--- a/programs/us_astfem_sim/us_astfem_sim.cpp
+++ b/programs/us_astfem_sim/us_astfem_sim.cpp
@@ -633,6 +633,7 @@ void US_Astfem_Sim::init_simparams( void )
    simparams.lrnoise           = 0.0;
    simparams.tinoise           = 0.0;
    simparams.rinoise           = 0.0;
+   simparams.baseline          = 0.0;
    simparams.band_volume       = 0.015;
    simparams.rotorCalID        = rotor_calibr;
    simparams.band_forming      = false;
@@ -1341,6 +1342,7 @@ void US_Astfem_Sim::finish( void )
 //DbgLv(1) << "FIN: comp size" << system.components.size();
 //DbgLv(1) << "FIN:  total_conc" << total_conc;
    ri_noise();
+   baseline();
    random_noise();
    ti_noise();
 
@@ -1390,6 +1392,21 @@ void US_Astfem_Sim::ri_noise( void )
 
            for ( int mp = 0; mp < sim_datas[ jd ].pointCount(); mp++ )
               sim_datas[ jd ].scanData[ ks ].rvalues[ mp ] += rinoise;
+       }
+   }
+}
+
+void US_Astfem_Sim::baseline( void )
+{
+   if ( simparams.baseline == 0.0 ) return;
+
+   // Add a constant baseline offset
+   for ( int jd = 0; jd < simparams.speed_step.size(); jd++ )
+   {
+       for ( int ks = 0; ks < sim_datas[ jd ].scanData.size(); ks++ )
+       {
+           for ( int mp = 0; mp < sim_datas[ jd ].pointCount(); mp++ )
+              sim_datas[ jd ].scanData[ ks ].rvalues[ mp ] += simparams.baseline;
        }
    }
 }

--- a/programs/us_astfem_sim/us_astfem_sim.cpp
+++ b/programs/us_astfem_sim/us_astfem_sim.cpp
@@ -2134,20 +2134,29 @@ void US_Astfem_Sim::plot( int step )
    QList< QColor > mcolors;
    int nmcols     = plot2->map_colors( mcolors );
   // dataPlotClear( scanPlot );
+   double min_y_axis = 0.0;
+   double max_y_axis = total_conc * 2.0;
 
-   // Set plot scale
+   // Set plot scale for band-forming
    if ( simparams.band_forming )
-      scanPlot->setAxisScale( QwtPlot::yLeft, 0, total_conc );
-
-   else if ( system.coSedSolute >= 0 )
+   {
+      min_y_axis = total_conc;
+   }
+   // adjust the plotting for the baseline offset if defined
+   if ( simparams.baseline != 0.0)
+   {
+      min_y_axis += simparams.baseline;
+      max_y_axis += simparams.baseline;
+   }
+   // For co-sedimenting solutes axis are auto-scaled
+   if ( system.coSedSolute >= 0 )
    {
       scanPlot->setAxisAutoScale( QwtPlot::xBottom );
       scanPlot->setAxisAutoScale( QwtPlot::yLeft   );
    }
-
    else
    {
-      scanPlot->setAxisScale( QwtPlot::yLeft, 0, total_conc * 2.0 );
+      scanPlot->setAxisScale( QwtPlot::yLeft, min_y_axis, max_y_axis );
    }
 
    QwtPlotGrid* grid2 = us_grid( scanPlot );

--- a/programs/us_astfem_sim/us_astfem_sim.h
+++ b/programs/us_astfem_sim/us_astfem_sim.h
@@ -115,6 +115,7 @@ class US_Astfem_Sim : public US_Widgets
       void   save_ultrascan ( const QString& );
       void   finish         ( void );
       void   ri_noise       ( void );
+      void   baseline       ( void );
       void   random_noise   ( void );
       void   ti_noise       ( void );
       void   plot           ( int  );

--- a/utils/us_simparms.cpp
+++ b/utils/us_simparms.cpp
@@ -30,6 +30,7 @@ US_SimulationParameters::US_SimulationParameters()
    lrnoise           = 0.0;
    tinoise           = 0.0;
    rinoise           = 0.0;
+   baseline          = 0.0;
    temperature       = NORMAL_TEMP;
    rotorCalID        = "0";
    band_forming      = false;
@@ -749,6 +750,9 @@ int US_SimulationParameters::load_simparms( QString fname )
             astr  = a.value( "rinoise"     ).toString();
             if ( !astr.isEmpty() )
                rinoise      = astr.toDouble();
+            astr  = a.value( "baseline"     ).toString();
+            if ( !astr.isEmpty() )
+               baseline     = astr.toDouble();
             astr  = a.value( "temperature" ).toString();
             if ( !astr.isEmpty() )
                temperature  = astr.toDouble();
@@ -850,6 +854,7 @@ int US_SimulationParameters::save_simparms( QString fname )
       xml.writeAttribute   ( "lrnoise",     QString::number( lrnoise ) );
       xml.writeAttribute   ( "tinoise",     QString::number( tinoise ) );
       xml.writeAttribute   ( "rinoise",     QString::number( rinoise ) );
+      xml.writeAttribute   ( "baseline",     QString::number( baseline ) );
       xml.writeAttribute   ( "temperature", QString::number( temperature ) );
 
       if ( ! rotorCalID.isEmpty() )
@@ -1529,6 +1534,7 @@ void US_SimulationParameters::debug( void )
    qDebug() << "Random noise (l):" << lrnoise;
    qDebug() << "Time Inv Noise  :" << tinoise;
    qDebug() << "Radial Inv Noise:" << rinoise;
+   qDebug() << "Baseline offset :" << baseline;
    qDebug() << "Band Forming    :" << band_forming;
    qDebug() << "Band Volume     :" << band_volume;
    qDebug() << "Rotor Calibr.ID :" << rotorCalID;

--- a/utils/us_simparms.h
+++ b/utils/us_simparms.h
@@ -176,6 +176,7 @@ class US_UTIL_EXTERN US_SimulationParameters
    double    lrnoise;           //!< Random noise, proportional to local concentration
    double    tinoise;           //!< Time invariant noise
    double    rinoise;           //!< Radially invariant noise
+   double    baseline;          //!< constant baseline offset, can be negative
    bool      band_forming;      //!< True for band-forming centerpieces
    double    band_volume;       //!< Loading volume (of lamella) in a 
                                 //!< Band-forming centerpiece


### PR DESCRIPTION
This pull request introduces a new feature to the simulation parameters GUI and backend: support for a constant baseline offset in simulation data. The changes span multiple files and include updates to the user interface, simulation logic, and parameter handling. Below is a summary of the most important changes:

### User Interface Enhancements:
* Added a new counter widget (`cnt_baseline`) in `US_SimParamsGui` to allow users to set a constant baseline offset in the GUI (`gui/us_sim_params_gui.cpp`, `gui/us_sim_params_gui.h`) [[1]](diffhunk://#diff-2b1f80b75236679502c57292a56bd92275cc1b59a8c7c28b9629675d6cf384dcR355-R368) [[2]](diffhunk://#diff-03262e7c8d7f958d8b2a1f564e79445611c6c47b875e2c9df6de63a89474288eR58).
* Connected the new `cnt_baseline` widget to the corresponding update method (`update_baseline`) and integrated it into the `backup_parms`, `revert`, `load`, `disconnect_all`, and `reconnect_all` methods (`gui/us_sim_params_gui.cpp`) [[1]](diffhunk://#diff-2b1f80b75236679502c57292a56bd92275cc1b59a8c7c28b9629675d6cf384dcR506) [[2]](diffhunk://#diff-2b1f80b75236679502c57292a56bd92275cc1b59a8c7c28b9629675d6cf384dcR542) [[3]](diffhunk://#diff-2b1f80b75236679502c57292a56bd92275cc1b59a8c7c28b9629675d6cf384dcR939) [[4]](diffhunk://#diff-2b1f80b75236679502c57292a56bd92275cc1b59a8c7c28b9629675d6cf384dcR1165) [[5]](diffhunk://#diff-2b1f80b75236679502c57292a56bd92275cc1b59a8c7c28b9629675d6cf384dcR1212-R1213).

### Simulation Logic Updates:
* Introduced a new method `baseline` in `US_Astfem_Sim` to apply the constant baseline offset to simulation data. This method adjusts data points by adding the specified baseline value (`programs/us_astfem_sim/us_astfem_sim.cpp`, `programs/us_astfem_sim/us_astfem_sim.h`) [[1]](diffhunk://#diff-28b2cf4a68bd31ed65de2e4887516cce99e23056b0cf36b2ea1429dfcaf5d20eR1399-R1413) [[2]](diffhunk://#diff-ab0f15fad6931ea0f1dc1b49d27dcd99365223df1c43120cf9c394fd9ca91dc8R118).
* Updated the `plot` method in `US_Astfem_Sim` to account for the baseline offset when determining the y-axis scale (`programs/us_astfem_sim/us_astfem_sim.cpp`).

### Parameter Handling Enhancements:
* Added a new `baseline` field to the `US_SimulationParameters` class to store the baseline offset. This field is initialized to `0.0` and can be saved to or loaded from simulation parameter files (`utils/us_simparms.cpp`, `utils/us_simparms.h`) [[1]](diffhunk://#diff-1ae153838b612c5bd97eb51f749269767fca7f7ff13accb9de608e86407da4f0R33) [[2]](diffhunk://#diff-10c51730f3456e49a8ca0b957f7753c0b84413f9844e940976d490fa6569cbceR179).
* Included the `baseline` parameter in the `load_simparms`, `save_simparms`, and `debug` methods of `US_SimulationParameters` (`utils/us_simparms.cpp`) [[1]](diffhunk://#diff-1ae153838b612c5bd97eb51f749269767fca7f7ff13accb9de608e86407da4f0R753-R755) [[2]](diffhunk://#diff-1ae153838b612c5bd97eb51f749269767fca7f7ff13accb9de608e86407da4f0R857) [[3]](diffhunk://#diff-1ae153838b612c5bd97eb51f749269767fca7f7ff13accb9de608e86407da4f0R1537).

These changes collectively enhance the simulation tool by enabling users to define and visualize a constant baseline offset, improving both usability and functionality.