### PR TITLE
FIX: Adjust the calculation of the standard deviation for the weights

### DIFF
--- a/programs/us_ga_init/us_solutedata.cpp
+++ b/programs/us_ga_init/us_solutedata.cpp
@@ -1092,6 +1092,7 @@ void US_SoluteData::outputStats( QTextStream& ts, QList< qreal >& vals,
    qreal   vm3        = 0.0;
    qreal   vm4        = 0.0;
    qreal   vmean;
+   qreal   vctot_square = 0.0;
    qreal   mode_cen;
    qreal   mode_lo;
    qreal   mode_hi;
@@ -1136,16 +1137,18 @@ void US_SoluteData::outputStats( QTextStream& ts, QList< qreal >& vals,
    for ( int jj = 0; jj < nvals; jj++ )
    {
       val       = vals.at( jj );
+      conc      = concs.at( jj );
       qreal dif = val - vmean;
       qreal dsq = dif * dif;
-      vm2      += dsq;           // diff squared
-      vm3      += ( dsq * dif ); // cubed
-      vm4      += ( dsq * dsq ); // to the 4th
+      vm2      += dsq * conc;           // diff squared
+      vm3      += ( dsq * dif ) * conc; // cubed
+      vm4      += ( dsq * dsq ) * conc; // to the 4th
+      vctot_square += conc * conc;
    }
 
-   vm2      /= vsiz;
-   vm3      /= vsiz;
-   vm4      /= vsiz;
+   vm2      *= vctot_square / (vctot*vctot - vctot_square);
+   vm3      *= vctot_square / (vctot*vctot - vctot_square);
+   vm4      *= vctot_square / (vctot*vctot - vctot_square);
    skew      = vm3 / pow( vm2, 1.5 );
    kurto     = vm4 / pow( vm2, 2.0 ) - 3.0;
    vmedi     = ( vlo + vhi ) / 2.0;


### PR DESCRIPTION
This pull request updates the statistical calculations in the `outputStats` method of `US_SoluteData` to properly weight higher-order moments (variance, skewness, kurtosis) by concentration. The changes ensure that the calculations account for concentration weighting, which improves the accuracy of the reported statistics.

**Statistical computation improvements:**

* The second, third, and fourth moments (`vm2`, `vm3`, `vm4`) are now weighted by concentration (`conc`) during their accumulation, rather than being simple averages.
* A new variable, `vctot_square`, is introduced to accumulate the sum of squared concentrations, which is then used to normalize the weighted moments. [[1]](diffhunk://#diff-966047d89bddd5a617785574c9af62bbcb86e884dc89af45f8c513a4bcc5722cR1095) [[2]](diffhunk://#diff-966047d89bddd5a617785574c9af62bbcb86e884dc89af45f8c513a4bcc5722cR1140-R1151)
* The normalization of the moments now uses a formula involving `vctot` and `vctot_square` to ensure correct concentration-weighted statistics.