### PR TITLE
Lukas/bad timestate

### DIFF
--- a/programs/us_2dsa/us_2dsa.cpp
+++ b/programs/us_2dsa/us_2dsa.cpp
@@ -1152,47 +1152,30 @@ DbgLv(1)<<"2dsa : timestate newly created.  timestateobject = "
    // Compute speed steps from sim speed profile
    dset.simparams.speedstepsFromSSprof();
 
-   // Do a quick test of the speed step implied by TimeState
-   int     tf_scan   = dset.simparams.speed_step[ 0 ].time_first;
-   int     accel1    = dset.simparams.speed_step[ 0 ].acceleration;
-   QString svalu     = US_Settings::debug_value( "SetSpeedLowA" );
-   int     lo_ss_acc = svalu.isEmpty() ? 250 : svalu.toInt();
-   int     rspeed    = dset.simparams.speed_step[ 0 ].rotorspeed;
-   int     accel2    = dset.simparams.sim_speed_prof[ 0 ].acceleration;
-   double  tf_aend   = static_cast<double>(tf_scan);
-   // prevent any division by zero
-   if (accel1 != 0)
-   {
-      tf_aend = static_cast<double>(rspeed) / static_cast<double>(accel1);
-   }
-
-DbgLv(1)<<"2dsa : ssck: rspeed accel1 tf_aend tf_scan"
- << rspeed << accel1 << tf_aend << tf_scan
- << "accel2" << accel2 << "lo_ss_acc" << lo_ss_acc;
-//x0  1  2  3  4  5
-   if ( accel1 < lo_ss_acc  ||  tf_aend > ( tf_scan - 3 ) )
-   {
-      QString wmsg = tr( "The TimeState used is likely bad:<br/>"
-                         "The acceleration implied is %1 rpm/sec.<br/>"
-                         "The acceleration zone ends at %2 seconds,<br/>"
-                         "with a first scan time of %3 seconds.<br/><br/>"
-                         "<b>You should rerun the experiment without<br/>"
-                         "any interim constant speed, and then<br/>"
-                         "you should reimport the data.</b>" )
-                     .arg( accel1 ).arg( QString::number(tf_aend) ).arg( QString::number(tf_scan) );
-
+   QStringList check_results = US_AstfemMath::check_acceleration(dset.simparams.speed_step, dset.run_data.scanData);
+   if ( !check_results.isEmpty() ) {
       QMessageBox msgBox( this );
-      msgBox.setWindowTitle( tr( "Bad TimeState Implied!" ) );
-      msgBox.setTextFormat( Qt::RichText );
-      msgBox.setText( wmsg );
+      msgBox.setWindowTitle( tr( qPrintable( check_results[0] ) ) );
+      if ( check_results.size() > 2 ) {
+         msgBox.setTextFormat( Qt::RichText );
+         msgBox.setText( tr( qPrintable( check_results[1] ) ) );
+      }
+      if ( check_results.size() > 3 ) {
+         QString info = "";
+         for ( int i = 2; i < check_results.size(); i++ ) {
+            info += check_results[i] + "\n";
+         }
+         msgBox.setInformativeText( tr( qPrintable( info ) ) );
+      }
       msgBox.addButton( tr( "Continue" ), QMessageBox::RejectRole );
       QPushButton* bAbort = msgBox.addButton( tr( "Abort" ),
                                           QMessageBox::YesRole );
       msgBox.setDefaultButton( bAbort );
       msgBox.exec();
 
-      if ( msgBox.clickedButton() == bAbort )
+      if ( msgBox.clickedButton() == bAbort ) {
          return;
+      }
    }
 
    dset.run_data           = dataList[ drow ];

--- a/programs/us_autoflow_analysis/us_autoflow_analysis.cpp
+++ b/programs/us_autoflow_analysis/us_autoflow_analysis.cpp
@@ -2239,54 +2239,33 @@ void US_Analysis_auto::simulateModel( )
 	  simparams.speed_step[ 0 ].acceleration = (int)qRound( rate );
 	}
     }
-  
-  // Do a quick test of the speed step implied by TimeState
-  int tf_scan   = simparams.speed_step[ 0 ].time_first;
-  int accel1    = simparams.speed_step[ 0 ].acceleration;
-  QString svalu = US_Settings::debug_value( "SetSpeedLowA" );
-  int lo_ss_acc = svalu.isEmpty() ? 250 : svalu.toInt();
-  int rspeed    = simparams.speed_step[ 0 ].rotorspeed;
-  double  tf_aend   = static_cast<double>(tf_scan);
-  // prevent any division by zero
-  if (accel1 != 0)
-  {
-    tf_aend = static_cast<double>(rspeed) / static_cast<double>(accel1);
-  }
-  
-  qDebug() << "SimMdl: ssck: rspeed accel1 lo_ss_acc"
-	   << rspeed << accel1 << lo_ss_acc << "tf_aend tf_scan"
-	   << tf_aend << tf_scan;
-  //x0  1  2  3  4  5
-  // check if the acceleration rate is low or the first scan was taken before the acceleration ended
-  // Due to older, wrong timestate calculation there might be a case, in which the calculated end of acceleration can
-  // be up to 1 second later than expected, tf_scan + 1 accounts for this.
-  if ( accel1 < lo_ss_acc  ||  tf_aend > ( tf_scan + 1 ) )
-    {
-      QString wmsg = tr( "The TimeState computed/used is likely bad:<br/>"
-			 "The acceleration implied is %1 rpm/sec.<br/>"
-			 "The acceleration zone ends at %2 seconds,<br/>"
-			 "with a first scan time of %3 seconds.<br/><br/>"
-			 "<b>You should rerun the experiment without<br/>"
-			 "any interim constant speed, and then<br/>"
-			 "you should reimport the data.</b>" )
-	.arg( accel1 ).arg( QString::number(tf_aend) ).arg( QString::number(tf_scan) );
-      
-      QMessageBox msgBox( this );
-      msgBox.setWindowTitle( tr( "Bad TimeState Implied!" ) );
-      msgBox.setTextFormat( Qt::RichText );
-      msgBox.setText( wmsg );
-      msgBox.addButton( tr( "Continue" ), QMessageBox::RejectRole );
-      QPushButton* bAbort = msgBox.addButton( tr( "Abort" ),
-					      QMessageBox::YesRole    );
-      msgBox.setDefaultButton( bAbort );
-      msgBox.exec();
-      if ( msgBox.clickedButton() == bAbort )
-	{
-	  QApplication::restoreOverrideCursor();
-	  qApp->processEvents();
-	  return;
+	QStringList check_results = US_AstfemMath::check_acceleration(simparams.speed_step, edata.scanData);
+	if ( !check_results.isEmpty() ) {
+		QMessageBox msgBox( this );
+		msgBox.setWindowTitle( tr( qPrintable( check_results[0] ) ) );
+		if ( check_results.size() > 2 ) {
+			msgBox.setTextFormat( Qt::RichText );
+			msgBox.setText( tr( qPrintable( check_results[1] ) ) );
+		}
+		if ( check_results.size() > 3 ) {
+			QString info = "";
+			for ( int i = 2; i < check_results.size(); i++ ) {
+				info += check_results[i] + "\n";
+			}
+			msgBox.setInformativeText( tr( qPrintable( info ) ) );
+		}
+		msgBox.addButton( tr( "Continue" ), QMessageBox::RejectRole );
+		QPushButton* bAbort = msgBox.addButton( tr( "Abort" ),
+														QMessageBox::YesRole );
+		msgBox.setDefaultButton( bAbort );
+		msgBox.exec();
+
+		if ( msgBox.clickedButton() == bAbort ) {
+			QApplication::restoreOverrideCursor();
+			qApp->processEvents();
+			return;
+		}
 	}
-    }
   sdata->cell        = rdata->cell;
   sdata->channel     = rdata->channel;
   sdata->description = rdata->description;

--- a/programs/us_convert/us_convert_gui.cpp
+++ b/programs/us_convert/us_convert_gui.cpp
@@ -10053,52 +10053,43 @@ DbgLv(1) << "CGui:IOD:   cSS nspeed" << speedsteps.size();
          low_accel        = US_AstfemMath::low_acceleration( speedsteps, ss_lo_acc, rate );
       }
    }
+	QStringList check_results = US_AstfemMath::check_acceleration(speedsteps, allData[0].scanData);
+	if ( !check_results.isEmpty() ) {
+		// append the notice about the recalculation
+		check_results << tr( "By clicking 'Continue', the experiment will be adjusted to occur as performed with a "
+							  "linear acceleration profile with a rate of 400 rpm/s." );
+		QMessageBox msgBox( this );
+		msgBox.setWindowTitle( tr( qPrintable( check_results[0] ) ) );
+		if ( check_results.size() > 2 ) {
+			msgBox.setTextFormat( Qt::RichText );
+			msgBox.setText( tr( qPrintable( check_results[1] ) ) );
+		}
+		if ( check_results.size() > 3 ) {
+			QString info = "";
+			for ( int i = 2; i < check_results.size(); i++ ) {
+				info += check_results[i] + "\n";
+			}
+			msgBox.setInformativeText( tr( qPrintable( info ) ) );
+		}
+		msgBox.addButton( tr( "Continue" ), QMessageBox::RejectRole );
+		QPushButton* bAbort = msgBox.addButton( tr( "Abort" ),
+														QMessageBox::YesRole );
+		msgBox.setDefaultButton( bAbort );
+		msgBox.exec();
 
-   // Report problematic 1st speed step
-   if ( low_accel )
-   {
-      int tf_scan      = speedsteps[ 0 ].time_first;
-      int accel1       = (int)qRound( rate );
-      int rspeed       = speedsteps[ 0 ].rotorspeed;
-   	double  tf_aend   = static_cast<double>(tf_scan);
-   	// prevent any division by zero
-   	if (accel1 != 0)
-   	{
-   		tf_aend = static_cast<double>(rspeed) / static_cast<double>(accel1);
-   	}
-
-
-      QString wmsg = tr( "The SpeedStep computed/used is likely bad:<br/>"
-                         "The acceleration implied is %1 rpm/sec.<br/>"
-                         "The acceleration zone ends at %2 seconds,<br/>"
-                         "with a first scan time of %3 seconds.<br/><br/>"
-                         "<b>You should rerun the experiment without<br/>"
-                         "any interim constant speed, and then<br/>"
-                         "you should reimport the data.</b>" )
-                     .arg( accel1 ).arg( QString::number(tf_aend) ).arg( QString::number(tf_scan) );
-
-      QMessageBox msgBox( this );
-      msgBox.setWindowTitle( tr( "Bad TimeState Implied!" ) );
-      msgBox.setTextFormat( Qt::RichText );
-      msgBox.setText( wmsg );
-      msgBox.addButton( tr( "Continue" ), QMessageBox::RejectRole );
-      QPushButton* bAbort = msgBox.addButton( tr( "Abort" ),
-            QMessageBox::YesRole    );
-      msgBox.setDefaultButton( bAbort );
-      msgBox.exec();
-      if ( msgBox.clickedButton() == bAbort )
-      {  // Abort the import of this data
-         QApplication::restoreOverrideCursor();
-         qApp->processEvents();
-         reset();
-         return false;
-      }
-      else
-      {  // Modify times and omegas of this data, then proceed to import
-         int status = US_Convert::adjustSpeedstep( allData, speedsteps );
-DbgLv(1) << "CGui:IOD: adjSS stat" << status;
-      }
-   }
+		if ( msgBox.clickedButton() == bAbort )
+		{  // Abort the import of this data
+			QApplication::restoreOverrideCursor();
+			qApp->processEvents();
+			reset();
+			return false;
+		}
+		else
+		{  // Modify times and omegas of this data, then proceed to import
+			int status = US_Convert::adjustSpeedstep( allData, speedsteps );
+			DbgLv(1) << "CGui:IOD: adjSS stat" << status;
+		}
+	}
 
    // MultiWaveLength if channels and triples counts differ
    isMwl            = ( all_chaninfo.count() != all_tripinfo.count() );

--- a/utils/us_astfem_math.h
+++ b/utils/us_astfem_math.h
@@ -45,6 +45,13 @@ class US_UTIL_EXTERN US_AstfemMath
       static bool low_acceleration( const QVector< US_SimulationParameters::SpeedProfile >&,
                                     const double, double& );
 
+      //! \brief Check for linear acceleration in the experimental data
+      //! \param speed_profiles  Vector of speed steps
+      //! \param scans       Vector of scans
+      //! \returns results   QStringList for the acceleration check title, body
+      static QStringList check_acceleration( const QVector< US_SimulationParameters::SpeedProfile >& speed_profiles,
+                                             const QVector< US_DataIO::Scan >& scans);
+
       //! \brief Determine if a timestate file holds one-second-interval records
       //! \param tmst_fpath  Full path to timestate file to examine
       //! \param sim_data    Raw data with scans to examine


### PR DESCRIPTION
This pull request refactors and centralizes the logic for checking problematic acceleration profiles in experimental ultracentrifugation data. The main improvement is the introduction of a new utility function, `US_AstfemMath::check_acceleration`, which standardizes the detection and reporting of low or non-linear acceleration issues across multiple applications. This change replaces duplicated inline logic with calls to the new function, improving maintainability and consistency of user warnings.

**Centralization of acceleration checks:**

* Added the new method `check_acceleration` to `US_AstfemMath`, which analyzes speed profiles and scan data to determine if the acceleration is too low or if the first scan occurs during acceleration, returning detailed user-facing messages. [[1]](diffhunk://#diff-ae6b16bdc3c037227d7f4fcb4bedb12d8ee7b99bbe02a307d8ac99017f158f8dR281-R373) [[2]](diffhunk://#diff-ad161883ae0595e91eafc4b73efd756ef5c4e155aaee5e17bcf01abeb74f65e0R48-R54)

**Refactoring of acceleration warnings in application code:**

* Updated `us_2dsa.cpp`, `us_autoflow_analysis.cpp`, and `us_convert_gui.cpp` to replace their custom acceleration check and warning logic with calls to `US_AstfemMath::check_acceleration`, ensuring consistent user messaging and reducing code duplication. [[1]](diffhunk://#diff-efac31c13c310bb074d230d39c7329eb20121f0ee0db1697cb38ef9def232502L1155-R1179) [[2]](diffhunk://#diff-5c792c9aeeb264cbd0519a1c4b70c8c89e0d6097b42c8635766b964670ff3745L2242-R2263) [[3]](diffhunk://#diff-a1985a9cb7fc1d0a4eb69218dd85fb714357e21393ee7f80f1df20f28ca4fb5aL10056-R10079)

**Improvements to user messaging:**

* Enhanced the warning dialogs to display more informative and context-specific messages, including possible consequences and recommended actions, and in the case of `us_convert_gui.cpp`, an additional notice about how the experiment will be adjusted if the user continues. [[1]](diffhunk://#diff-a1985a9cb7fc1d0a4eb69218dd85fb714357e21393ee7f80f1df20f28ca4fb5aL10056-R10079) [[2]](diffhunk://#diff-efac31c13c310bb074d230d39c7329eb20121f0ee0db1697cb38ef9def232502L1155-R1179)

**Documentation and interface updates:**

* Updated the header file `us_astfem_math.h` to document the new `check_acceleration` method and its parameters.

These changes improve code quality, user experience, and make it easier to maintain and extend acceleration-related checks in the future.