### PR TITLE
Document advanced settings debug text values/flags

### DIFF
--- a/doc/manual/advanced_config.body
+++ b/doc/manual/advanced_config.body
@@ -56,7 +56,7 @@
                   <b>pcsaTiming</b> Flag to print debug timings in us_pcsa.
                </li>
                <li>
-                  <b>hsclogo</b> Flag to include the HS logo in the generated reports.
+                  <b>hsclogo</b> Flag to include the University of Texas Health Science Center logo in the generated reports.
                </li>
                <li>
                   <b>becklogo</b> Flag to include the Beckman logo in the generated reports.


### PR DESCRIPTION
This pull request updates the documentation to provide detailed descriptions for several advanced configuration debug text phrases. The new documentation helps users understand the purpose and default values of each debug flag, making configuration more transparent and user-friendly.

Newly documented debug configuration options:

**Speed and acceleration settings:**
* Added descriptions for `SetSpeedResolution`, `SetSpeedLowAcc`, and `SetSpeedLowR`, explaining their roles in speed resolution and acceleration thresholds, including their default values.
* Documented `SpeedStepLowSec`, specifying its function in defining a minimum duration for constant speed zones.

**Analysis and algorithm flags:**
* Added explanations for `normCutoff`, `2dsaFinalNoiseOnly`, and `MC-GaussianSmooth`, clarifying their roles in data processing and noise correction.

**Debug and reporting options:**
* Documented flags such as `2dsaTiming`, `protocolFromDisk`, `men2click`, `pcsaTiming`, `hsclogo`, `becklogo`, and `us3logo`, detailing their effects on debugging output, protocol loading, user interaction, and report branding.