### PR TITLE
PROT.DEV.: dataDisk type -- pass correct invID  (data owner)

### DIFF
--- a/gui/us_convert_gui.cpp
+++ b/gui/us_convert_gui.cpp
@@ -1402,8 +1402,9 @@ void US_ConvertGui::us_mode_passed( void )
 void US_ConvertGui::download_data_auto( QMap < QString, QString > & details_at_live_update )
 {
    QString filenameProtDevDataDisk = details_at_live_update[ "filenameProtDevDataDisk" ];
-   qDebug() << "[Prot_DEV: download_data_auto() ], filenameProtDevDataDisk -- "
-	    << filenameProtDevDataDisk;
+   QString invID_fromProt = details_at_live_update[ "invID_passed" ];
+   qDebug() << "[Prot_DEV: download_data_auto() ], filenameProtDevDataDisk, invID -- "
+	    << filenameProtDevDataDisk << ", " << invID_fromProt;
 
    runID = ( filenameProtDevDataDisk.isEmpty() ) ?
      details_at_live_update[ "filename" ] : filenameProtDevDataDisk;
@@ -1429,7 +1430,7 @@ void US_ConvertGui::download_data_auto( QMap < QString, QString > & details_at_l
 	    << runID;
 
    QString status = US_ConvertIO::readDBExperiment( runID, dirname, &db,
-                                                    speedsteps );
+                                                    speedsteps, invID_fromProt );
    if ( status  != QString( "" ) )
      {
        QMessageBox::information( this, tr( "Error" ), status + "\n" );

--- a/programs/us_protocol_dev/us_protocol_dev_gui.cpp
+++ b/programs/us_protocol_dev/us_protocol_dev_gui.cpp
@@ -1213,6 +1213,7 @@ void US_InitDialogueGui::initRecordsDialogue( void )
 		  QMap< QString, QString > p_det;
 		  p_det["filename"] = filename_from_dataPath;
 		  p_det["filenameProtDevDataDisk"] = filenameProtDevDataDisk;
+		  p_det["invID_passed"] = invID_passed;
 		  sdiag_convert->download_data_auto( p_det );
 
 		  qApp->processEvents();

--- a/utils/us_convertio.cpp
+++ b/utils/us_convertio.cpp
@@ -295,13 +295,17 @@ qDebug() << "cvio:WrRDB: newExp id solID chnID" << ExpData.expID
 
 // Function to read the experiment info and binary auc files to disk
 QString US_ConvertIO::readDBExperiment( QString runID, QString dir,
-          US_DB2* db, QVector< SP_SPEEDPROFILE >& speedsteps )
+					US_DB2* db, QVector< SP_SPEEDPROFILE >& speedsteps,
+					const QString invid_p )
 
 {
    US_Experiment ExpData;                    // A local copy of experiment
    QList< US_Convert::TripleInfo > triples;  // A local copy of triples
-qDebug() << "rDBE: call ExpData.readFromDB";
-   int readStatus = ExpData.readFromDB( runID, db, speedsteps );
+   qDebug() << "rDBE: call ExpData.readFromDB";
+
+   qDebug() << "US_ConvertIO::readDBExperiment, invid_p -- " << invid_p;
+   
+   int readStatus = ExpData.readFromDB( runID, db, speedsteps, invid_p );
 if(speedsteps.size()>0)
  qDebug() << "rDBE:  ss size ss0.sp ss0.avg" << speedsteps.size()
  << speedsteps[0].rotorspeed << speedsteps[0].avg_speed;

--- a/utils/us_convertio.h
+++ b/utils/us_convertio.h
@@ -35,7 +35,7 @@ class US_ConvertIO
           \param speedsteps Reference for returned experiment speed steps vector
       */
       static QString readDBExperiment( QString, QString, US_DB2*,
-                        QVector< SP_SPEEDPROFILE >& );
+				       QVector< SP_SPEEDPROFILE >&, const QString = QString("") );
 
       /*! \brief Writes a new DB rawData record for each triple
 

--- a/utils/us_experiment.cpp
+++ b/utils/us_experiment.cpp
@@ -305,11 +305,17 @@ qDebug() << "Exp:svToDB:     ssstat=" << ssstat;
 
 // Function to read an experiment from DB
 int US_Experiment::readFromDB( QString runID, US_DB2* db,
-                               QVector< SP_SPEEDPROFILE >& speedsteps )
+                               QVector< SP_SPEEDPROFILE >& speedsteps,
+			       const QString invid_p )
 {
+   qDebug() << "US_Experiment::readFromDB, invid_p -- " << invid_p;
+   
+   QString invID_to_use = ( invid_p.isEmpty() ) ?
+     QString::number( US_Settings::us_inv_ID() ) : invid_p;
    QStringList q( "get_experiment_info_by_runID" );
    q << runID
-     << QString::number( US_Settings::us_inv_ID() );
+     //<< QString::number( US_Settings::us_inv_ID() );
+     << invID_to_use;
    db->query( q );
 
    qDebug() << "US_Experiment::readFromDB: q -- " << q;

--- a/utils/us_experiment.h
+++ b/utils/us_experiment.h
@@ -103,7 +103,7 @@ class US_Experiment
           \param    speedsteps Reference to vector of experiment speed steps
           \returns  One of the US_DB2 error codes
       */
-      int readFromDB( QString, US_DB2*, QVector< SP_SPEEDPROFILE >& );
+      int readFromDB( QString, US_DB2*, QVector< SP_SPEEDPROFILE >&, const QString = QString("")  );
 
       /*! \brief    Writes an xml file
 


### PR DESCRIPTION
Passes correct invID associated with the dataDisk to-be-reanalysed for download from DB: (1) during creation of a new run using data produced by different owner; (2) during re-attachment from different session/different user (which would require fresh download)...

Tested on several examples.