### PR TITLE
GMP: 4.EDIT -- when reading Apofile's data for Scan Exclusions, check hat every nth scan not be 0…

### DIFF
--- a/programs/us_edit/us_edit.cpp
+++ b/programs/us_edit/us_edit.cpp
@@ -3800,7 +3800,13 @@ DbgLv(1) << "IS-MWL: celchns size" << celchns.size();
 	       if ( channelname_.contains(ci.key()) )
 		 {
 		   qDebug() << "Channel, AProfile SCANSS: " << channelname_ << ", " << ci.key() << ": " << ci.value();
-		   editProfile_scans_excl[ triple_name ] = ci.value();
+		   QStringList scans_set = ci.value();
+
+		   //check
+		   if (scans_set[2] == QString("0") )
+		     scans_set[2] = QString::number(1);
+		   
+		   editProfile_scans_excl[ triple_name ] = scans_set;
 		   break;
 		 }
 	       ++ci;


### PR DESCRIPTION
Fixed for cases when every nth scan in Scan Exclusions Setting if AProfile is undefined (or 0) causing crash at re-attachment at 4. EDIT stage  