### PR TITLE
Lukas/cmake fixes

### DIFF
--- a/gui/us_analysis_base2.cpp
+++ b/gui/us_analysis_base2.cpp
@@ -399,7 +399,7 @@ void US_AnalysisBase2::update( int selection )
    US_SimulationParameters simulationParameters = US_SimulationParameters();
    QVector<US_SimulationParameters::SpeedProfile> speed_profiles;
    speed_profiles.clear();
-   if ( disk_controls->db() )
+   if ( disk_controls->db() && dbP != nullptr )
    {
      QStringList query;
      QString     expID;

--- a/programs/CMakeLists.txt
+++ b/programs/CMakeLists.txt
@@ -136,6 +136,13 @@ endif()
 
 if(WIN32)
     target_compile_definitions(us_program_common INTERFACE QWT_DLL QT_DLL)
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        if(MINGW)
+            target_link_options(us_program_common INTERFACE "-mwindows")
+        elseif(MSVC)
+            target_link_options(us_program_common INTERFACE "/SUBSYSTEM:WINDOWS" "/ENTRY:mainCRTStartup")
+        endif()
+    endif()
 endif()
 
 # --------------------------------------------------------------------------

--- a/programs/us/CMakeLists.txt
+++ b/programs/us/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 if(WIN32)
         # Create us.rc if it doesn't exist
         if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/us.rc")
-                file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/us.rc" "IDI_ICON1 ICON \"../../gui/images/us3-icon-256x256.png\"\n")
+                file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/us.rc" "IDI_ICON1 ICON \"../../etc/us3-icon-128x128.ico\"\n")
         endif()
         list(APPEND US_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/us.rc")
 endif()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -51,6 +51,12 @@ elseif(WIN32)
     set_target_properties(us_utils PROPERTIES
             WINDOWS_EXPORT_ALL_SYMBOLS OFF  # We'll use explicit exports
             )
+    # Use BigObj format for large files
+    if(MSVC)
+        target_compile_options(us_utils PRIVATE "/bigobj")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(us_utils PRIVATE "-Wa,-mbig-obj")
+    endif()
 endif()
 
 # Ensure dynamic Qt linking - ALL PLATFORMS
@@ -177,6 +183,12 @@ if(BUILD_TESTING OR US3_PREFER_STATIC)
         endif()
     elseif(WIN32)
         target_link_libraries(us_utils_static PUBLIC ${WIN32_SYSTEM_LIBS})
+        # Use BigObj format for large files
+        if(MSVC)
+            target_compile_options(us_utils PRIVATE "/bigobj")
+        elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(us_utils PRIVATE "-Wa,-mbig-obj")
+        endif()
     endif()
 
     # Debug options
@@ -186,17 +198,6 @@ if(BUILD_TESTING OR US3_PREFER_STATIC)
         else()
             target_compile_options(us_utils_static PRIVATE -g -O0)
         endif()
-    endif()
-    # Platform-specific libraries
-    if(UNIX AND NOT APPLE)
-        # Linux-specific libraries
-        if(X11_FOUND)
-            target_link_libraries(us_utils_static PUBLIC ${X11_LIBRARIES})
-            target_include_directories(us_utils_static PUBLIC ${X11_INCLUDE_DIR})
-        endif()
-    elseif(WIN32)
-        # Windows system libraries
-        target_link_libraries(us_utils_static PUBLIC ${WIN32_SYSTEM_LIBS})
     endif()
 
     # Export static library alias

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -185,9 +185,9 @@ if(BUILD_TESTING OR US3_PREFER_STATIC)
         target_link_libraries(us_utils_static PUBLIC ${WIN32_SYSTEM_LIBS})
         # Use BigObj format for large files
         if(MSVC)
-            target_compile_options(us_utils PRIVATE "/bigobj")
+            target_compile_options(us_utils_static PRIVATE "/bigobj")
         elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-            target_compile_options(us_utils PRIVATE "-Wa,-mbig-obj")
+            target_compile_options(us_utils_static PRIVATE "-Wa,-mbig-obj")
         endif()
     endif()
 


### PR DESCRIPTION
This pull request introduces several improvements to Windows build configuration and resource handling for the project. The main changes focus on optimizing compilation for large files, updating icon resources, and refining platform-specific linker options.

Windows build optimizations:

* Added BigObj format support for large files in `us_utils` and `us_utils_static` targets, using `/bigobj` for MSVC and `-Wa,-mbig-obj` for GNU/Clang compilers. (`utils/CMakeLists.txt`) [[1]](diffhunk://#diff-876710895623d6551ed7ae3d953269d1f91ba337e03387c1155c003d33928350R54-R59) [[2]](diffhunk://#diff-876710895623d6551ed7ae3d953269d1f91ba337e03387c1155c003d33928350R186-R191)

Platform-specific linker options:

* For Windows Release builds, added linker options for MinGW (`-mwindows`) and MSVC (`/SUBSYSTEM:WINDOWS`, `/ENTRY:mainCRTStartup`) to the `us_program_common` target. (`programs/CMakeLists.txt`)

Resource handling:

* Updated the icon resource in `us.rc` to use a `.ico` file instead of a `.png`, improving compatibility and appearance. (`programs/us/CMakeLists.txt`)

Platform-specific library linking cleanup:

* Removed redundant platform-specific library linking and include directives for `us_utils_static`, simplifying the CMake configuration. (`utils/CMakeLists.txt`)