### PR TITLE
Ensure zoom stack initialization on zoom button press

### DIFF
--- a/gui/us_plot.cpp
+++ b/gui/us_plot.cpp
@@ -41,31 +41,48 @@ US_Zoomer::US_Zoomer( const int xAxis, const int yAxis, QwtPlotCanvas* canvas )
    toggle_zoom_events( this, false );
 }
 
-void US_Zoomer::begin(  ) {
-   if (!zoom_base_set) {
-      QwtPlot* plot = QwtPlotZoomer::plot();
-      if ( plot && plot->itemList(QwtPlotItem::Rtti_PlotCurve).count() > 0 ) {
-         // first zoom event, check if the zoomStack is properly set
-         // Get the actual axis values
-         auto xa = plot->axisScaleDiv( xAxis() );
-         auto ya = plot->axisScaleDiv( yAxis() );
-         auto x_min = xa.lowerBound();
-         auto x_max = xa.upperBound();
-         auto y_min = ya.lowerBound();
-         auto y_max = ya.upperBound();
-         auto zoom_base = zoomBase();
-         if ( !qFuzzyCompare(zoom_base.left(), x_min ) ||
-            !qFuzzyCompare(zoom_base.right(), x_max ) ||
-            !qFuzzyCompare(zoom_base.top(), y_min ) ||
-            !qFuzzyCompare(zoom_base.bottom(), y_max ) ) {
-            auto zoom_stack = QStack<QRectF>();
-            zoom_stack << QRectF( x_min, y_min, x_max - x_min, y_max - y_min );
-            const QSignalBlocker blocker(this);
-            setZoomStack(zoom_stack, -1);
-            zoom_base_set = true;
-            }
-      }
+void US_Zoomer::initializeZoomStack( QwtPlotZoomer* zoomer ) {
+   if ( zoomer == nullptr ) {
+      return;
    }
+   if ( zoomer->zoomStack().size() > 1) {
+      return;
+   }
+   const QwtPlot* plot = zoomer->plot();
+   if ( plot && plot->itemList(QwtPlotItem::Rtti_PlotCurve).count() == 0 ) {
+      return;
+   }
+   // first zoom event, check if the zoomStack is properly set
+   // Get the actual axis values
+   const auto xa = plot->axisScaleDiv( zoomer->xAxis() );
+   const auto ya = plot->axisScaleDiv( zoomer->yAxis() );
+   const auto x_min = xa.lowerBound();
+   const auto x_max = xa.upperBound();
+   const auto y_min = ya.lowerBound();
+   const auto y_max = ya.upperBound();
+   const auto zoom_base = zoomer->zoomBase();
+
+   // if zoom base is within 10% of the actual axis values, do not reset zoom stack
+   if ( x_min * 0.9 <= zoom_base.left() && zoom_base.left() <= x_min * 1.1 &&
+      y_min * 0.9 <= zoom_base.top() && zoom_base.top() <= y_min * 1.1 &&
+      x_max * 0.9 <= zoom_base.right() && zoom_base.right() <= x_max * 1.1 &&
+      y_max * 0.9 <= zoom_base.bottom() && zoom_base.bottom() <= y_max * 1.1 ) {
+      return;
+   }
+   if ( !qFuzzyCompare(zoom_base.left(), x_min ) ||
+        !qFuzzyCompare(zoom_base.right(), x_max ) ||
+        !qFuzzyCompare(zoom_base.top(), y_min ) ||
+        !qFuzzyCompare(zoom_base.bottom(), y_max ) ) {
+      auto zoom_stack = QStack<QRectF>();
+      zoom_stack << QRectF( x_min, y_min, x_max - x_min, y_max - y_min );
+      const QSignalBlocker blocker(zoomer);
+      zoomer->setZoomStack(zoom_stack, -1);
+   }
+}
+
+void US_Zoomer::begin(  ) {
+   initializeZoomStack( this );
+   zoom_base_set = true;
    QwtPlotZoomer::begin();
 }
 
@@ -539,6 +556,7 @@ void US_Plot::setZoomEnabled( bool enable )
       if ( panner ) panner->setEnabled( true );
       if ( zoomer )
       {
+         US_Zoomer::initializeZoomStack( zoomer );
          zoomer->setEnabled( true );
          zoomer->zoom( 0 );
          US_Zoomer::toggle_zoom_events(zoomer, true);

--- a/gui/us_plot.cpp
+++ b/gui/us_plot.cpp
@@ -49,7 +49,7 @@ void US_Zoomer::initializeZoomStack( QwtPlotZoomer* zoomer ) {
       return;
    }
    const QwtPlot* plot = zoomer->plot();
-   if ( plot && plot->itemList(QwtPlotItem::Rtti_PlotCurve).count() == 0 ) {
+   if ( plot == nullptr || plot->itemList(QwtPlotItem::Rtti_PlotCurve).count() == 0 ) {
       return;
    }
    // first zoom event, check if the zoomStack is properly set
@@ -63,10 +63,10 @@ void US_Zoomer::initializeZoomStack( QwtPlotZoomer* zoomer ) {
    const auto zoom_base = zoomer->zoomBase();
 
    // if zoom base is within 10% of the actual axis values, do not reset zoom stack
-   if ( x_min * 0.9 <= zoom_base.left() && zoom_base.left() <= x_min * 1.1 &&
-      y_min * 0.9 <= zoom_base.top() && zoom_base.top() <= y_min * 1.1 &&
-      x_max * 0.9 <= zoom_base.right() && zoom_base.right() <= x_max * 1.1 &&
-      y_max * 0.9 <= zoom_base.bottom() && zoom_base.bottom() <= y_max * 1.1 ) {
+   if ( qAbs(x_min * 0.9) <= qAbs(zoom_base.left()) && qAbs(zoom_base.left()) <= qAbs(x_min * 1.1) &&
+      qAbs(y_min * 0.9) <= qAbs(zoom_base.top()) && qAbs(zoom_base.top()) <= qAbs(y_min * 1.1) &&
+      qAbs(x_max * 0.9) <= qAbs(zoom_base.right()) && qAbs(zoom_base.right()) <= qAbs(x_max * 1.1) &&
+      qAbs(y_max * 0.9) <= qAbs(zoom_base.bottom()) && qAbs(zoom_base.bottom()) <= qAbs(y_max * 1.1) ) {
       return;
    }
    if ( !qFuzzyCompare(zoom_base.left(), x_min ) ||
@@ -81,7 +81,9 @@ void US_Zoomer::initializeZoomStack( QwtPlotZoomer* zoomer ) {
 }
 
 void US_Zoomer::begin(  ) {
-   initializeZoomStack( this );
+   if ( !zoom_base_set ) {
+	   initializeZoomStack( this );
+   }
    zoom_base_set = true;
    QwtPlotZoomer::begin();
 }

--- a/gui/us_plot.h
+++ b/gui/us_plot.h
@@ -39,6 +39,7 @@ class US_GUI_EXTERN US_Zoomer: public QwtPlotZoomer
       //! \param yAxis - The title of the y (left) axis
       //! \param canvas - A pointer to the plot's canvas
       US_Zoomer( int xAxis, int yAxis, QwtPlotCanvas* canvas );
+      static void initializeZoomStack( QwtPlotZoomer* zoomer );
       static void toggle_zoom_events( QwtPlotZoomer* zoomer, bool active_zoom_button);
       virtual void begin() override;
    private:


### PR DESCRIPTION
This pull request refactors and improves the initialization logic for the zoom stack in the `US_Zoomer` and related classes, making zoom stack management more robust and reusable. The main change is the introduction of a new static method, `initializeZoomStack`, which centralizes and clarifies how the zoom stack should be set up, and ensures it is called in the right places.

Key changes:

**Zoom stack initialization refactor:**
* Added a new static method `initializeZoomStack` to the `US_Zoomer` class, which encapsulates the logic for properly initializing the zoom stack for a given `QwtPlotZoomer` instance. This method checks if initialization is necessary, compares current zoom base with actual axis values, and only resets the zoom stack when needed. (`gui/us_plot.cpp`, `gui/us_plot.h`) [[1]](diffhunk://#diff-047f82a0178a00dea0fa29c1d685f36fccc516afd01858e985b545d021f381f1L44-R85) [[2]](diffhunk://#diff-d89ac3d760efb86a2507f8a06e20f7c9d43d5ebd470f2440cc977e5ce2ac9ca5R42)

**Integration of new initialization method:**
* Updated the `US_Zoomer::begin()` method to use the new `initializeZoomStack` function, simplifying the method and ensuring consistent zoom stack initialization. (`gui/us_plot.cpp`)
* Modified `US_Plot::setZoomEnabled` to call `US_Zoomer::initializeZoomStack` before enabling zoom, ensuring the zoom stack is always correctly set when zoom is enabled. (`gui/us_plot.cpp`)

These changes improve code clarity, prevent redundant zoom stack resets, and make it easier to maintain zoom-related logic.