### PR TITLE
Haben/docs crosslinking

### DIFF
--- a/doc/manual/source/config.rst
+++ b/doc/manual/source/config.rst
@@ -56,7 +56,7 @@ Configuration Functions
   * - **Database Preferences:** 
     - See the Database Configuration below on the :ref:`Change <dat_change>` button if you want to set the database username, password, database name and server host name.
   * - **Master Password:** 
-    - See the Database Configuration below on the :ref:`Change <mp_change>` button to set or reset your personal **UltraScanIII** password. Be sure to remember the password. If it is lost, you will need to reset all saved database information in the *Database Preferences* panel.
+    - See the Database Configuration below on the :ref:`Change <mp_change>` button to set or reset your personal **UltraScan-III** password. Be sure to remember the password. If it is lost, you will need to reset all saved database information in the *Database Preferences* panel.
   * - **Advanced Settings:** 
     - See the Database Configuration below on the :ref:`Change <adv_change>` button to set advanced settings related to debug, advanced level, and number of threads.
 


### PR DESCRIPTION
This pull request includes a minor documentation update to the configuration instructions. The only change is a small correction to the product name in the master password section to ensure consistency.

- Updated the master password section in the documentation to use the correct product name, changing **UltraScanIII** to **UltraScan-III**.