### PR TITLE
Database:Manage Models & US_Astfem: -- preclude segfault when clicking Edit Current Analyte in properties when no analyte uploaded and selected.

### DIFF
--- a/gui/us_properties.cpp
+++ b/gui/us_properties.cpp
@@ -1166,7 +1166,7 @@ void US_Properties::edit_analyte()
      {
        QMessageBox::information( this,
 				 tr( "UltraScan Information" ),
-				 tr( "No Analyte Selected:\n\n"
+				 tr( "No Analyte Selected\n\n"
 				     "Please select an analyte from the list before editing.") );
        return;
      }

--- a/gui/us_properties.cpp
+++ b/gui/us_properties.cpp
@@ -489,6 +489,7 @@ void US_Properties::set_oligomer( double oligomer )
 void US_Properties::edit_component( void )
 {
    int row = lw_components->currentRow();
+   
    if ( row < 0 ) return;
 
    QString desc = le_description->text().trimmed();
@@ -1157,7 +1158,19 @@ void US_Properties::source_changed( bool db )
 // Slot to edit the currently selected analyte
 void US_Properties::edit_analyte()
 {
+   qDebug() << "[Prop:edit_analyte()] 1";
    int row       = lw_components->currentRow();
+   qDebug() << "[Prop:edit_analyte()], row -- " << row;
+
+   if (row < 0 )
+     {
+       QMessageBox::information( this,
+				 tr( "UltraScan Information" ),
+				 tr( "No Selected Analyte :\n\n"
+				     "Please upload an analyte from DB first to proceed.") );
+       return;
+     }
+   
    QString aguid = le_guid->text();
    if ( aguid.isEmpty() )
       aguid         = model.components[ row ].analyteGUID;

--- a/gui/us_properties.cpp
+++ b/gui/us_properties.cpp
@@ -1166,8 +1166,8 @@ void US_Properties::edit_analyte()
      {
        QMessageBox::information( this,
 				 tr( "UltraScan Information" ),
-				 tr( "No Selected Analyte :\n\n"
-				     "Please upload an analyte from DB first to proceed.") );
+				 tr( "No Analyte Selected:\n\n"
+				     "Please select an analyte from the list before editing.") );
        return;
      }
    


### PR DESCRIPTION
Prevents segfault due to no items existing in the QListWidget for the analytes when clicking "Edit Current Analyte" - before uploading an anlayte(s) from DB.