### PR TITLE
1. EXP. setup for: GMP | R&D | Protocol Dev. -- Previous Panel & Next Panel buttons

### DIFF
--- a/programs/us_com_project/us_com_project_gui.cpp
+++ b/programs/us_com_project/us_com_project_gui.cpp
@@ -3026,6 +3026,8 @@ US_ExperGui::US_ExperGui( QWidget* topw )
 
    if ( mainw->us_mode_bool )
      sdiag->us_mode_passed();
+
+   sdiag->expPanelSet=true;
    
    sdiag->show();
 

--- a/programs/us_experiment/us_exp_utils.cpp
+++ b/programs/us_experiment/us_exp_utils.cpp
@@ -637,7 +637,7 @@ DbgLv(1) << "mainw->automode" << mainw->automode;
 	 }
      }
    //////////////////
-
+   mainw->enable_disable_prev_next_btns();
 }
 
 
@@ -923,6 +923,8 @@ void US_ExperGuiGeneral::savePanel()
    currProto->temeq_delay  = ct_tedelay     ->value();
 
    currProto->exp_label    = le_label       ->text();
+
+   mainw->pb_prev->setEnabled(true);
 
 }
 
@@ -3886,6 +3888,8 @@ QStringList US_ExperGuiAProfile::getLValue( const QString type )
 // Initialize an Upload panel, especially after clicking on its tab
 void US_ExperGuiUpload::initPanel()
 {
+   mainw->enable_disable_prev_next_btns();
+  
    currProto       = &mainw->currProto;
    loadProto       = &mainw->loadProto;
    //rps_differ      = ( mainw->currProto !=  mainw->loadProto );
@@ -4991,6 +4995,7 @@ bool US_ExperGuiUpload::areReportMapsDifferent( US_AnaProfile aprof_curr, US_Ana
 // Save panel controls when about to leave the panel
 void US_ExperGuiUpload::savePanel()
 {
+  mainw->pb_next->setEnabled( true );
 }
 
 // Get a specific panel value

--- a/programs/us_experiment/us_experiment_gui_optima.cpp
+++ b/programs/us_experiment/us_experiment_gui_optima.cpp
@@ -45,6 +45,7 @@ US_ExperimentMain::US_ExperimentMain() : US_Widgets()
    usmode = false;
    us_prot_dev_mode = false;
    us_abde_mode = false;
+   expPanelSet = false;
    
    global_reset = false;
    instruments_in_use.clear();
@@ -458,6 +459,9 @@ void US_ExperimentMain::accept_passed_protocol_details(  QMap < QString, QString
   protocol_details_passed.clear();
   protocol_details_passed = protocol_details;
 
+  expPanelSet=true;
+  enable_disable_prev_next_btns();
+  
   emit close_expsetup_msg();
 }
 
@@ -561,6 +565,20 @@ void US_ExperimentMain::auto_mode_passed( void )
   this->pb_close->hide();
 
   
+}
+
+void US_ExperimentMain::enable_disable_prev_next_btns( void )
+{
+  if ( !expPanelSet )
+    return;
+    
+  int totalTabs = tabWidget->count();
+  int lastTabIndex = totalTabs - 1;
+  int currTabIndex = tabWidget->currentIndex();
+  if ( currTabIndex == 0 )
+    pb_prev->setEnabled(false);
+  if ( currTabIndex == lastTabIndex )
+    pb_next->setEnabled(false);
 }
 
 // Reset parameters to their defaults

--- a/programs/us_experiment/us_experiment_gui_optima.h
+++ b/programs/us_experiment/us_experiment_gui_optima.h
@@ -1136,6 +1136,7 @@ class US_ExperimentMain : public US_Widgets
       bool    us_prot_dev_mode;
       bool    global_reset;
       bool    us_abde_mode;
+      bool    expPanelSet;
 
   QMap <QString, QString> protocol_details_passed; 
       
@@ -1144,6 +1145,7 @@ class US_ExperimentMain : public US_Widgets
       void    set_abde_mode_aprofile( void );
       void    unset_abde_mode_aprofile( void );
       void    abde_sv_mode_change_reset_reports( QString  );
+      void    enable_disable_prev_next_btns( void );
 
       QStringList instruments_in_use;
       QStringList instruments_no_permit;

--- a/programs/us_protocol_dev/us_protocol_dev_gui.cpp
+++ b/programs/us_protocol_dev/us_protocol_dev_gui.cpp
@@ -2142,6 +2142,8 @@ US_ExperGui::US_ExperGui( QWidget* topw )
 
    // if ( mainw->us_mode_bool )
    //   sdiag->us_mode_passed();
+
+   sdiag->expPanelSet=true;
    
    sdiag->show();
 }


### PR DESCRIPTION
1. EXP stage in the programs:

* GMP -> Data Acquisition Routine
* Utilities -> Data Acquisition
* GMP -> Protocol Development

Corrected behavior of the Previous Panel (PP) & Next Panel (NP) buttons: 
(1) PP Enabled when not the first tab selected, enabled otherwise
(2) NP Enabled when not last tab selected, enabled otherwise 