### PR TITLE
GMP: 2. Rotor/Labs  tab: Add to List bttns

### DIFF
--- a/programs/us_experiment/us_exp_utils.cpp
+++ b/programs/us_experiment/us_exp_utils.cpp
@@ -1101,6 +1101,9 @@ DbgLv(1) << "EGRo: inP: calib_entr" << cal_entr;
    init_gapprs();
    init_gsmes();
 
+   //Disable Add To List for [o | r | a | sme ] if respective lists are empty
+   setEnabledDisabledAddToORASME();
+
    //BAsed on mode [usmode - R&D], hide/show oper/rev section:
       //show Assign oper/rev ONLY for GMP:
    qDebug() << "In Rotor: mainw->automode, mainw->usmode -- "
@@ -1163,6 +1166,21 @@ DbgLv(1) << "EGRo: inP: calib_entr" << cal_entr;
    qDebug() << "Rotor::initPanel(), rpRotor->importData_absorbance_t, rpRotor->importData_absorbance_pa -- "
 	    << rpRotor->importData_absorbance_t <<  rpRotor->importData_absorbance_pa;
 
+}
+
+void US_ExperGuiRotor::setEnabledDisabledAddToORASME( void )
+{
+  bool isOperEmpty = cb_choose_operator->count() == 0;
+  pb_add_oper->setEnabled( !isOperEmpty );
+
+  bool isRevEmpty = cb_choose_rev->count() == 0;
+  pb_add_rev->setEnabled( !isRevEmpty );
+
+  bool isApprEmpty = cb_choose_appr->count() == 0;
+  pb_add_appr->setEnabled( !isApprEmpty );
+
+  bool isSmeEmpty = cb_choose_sme->count() == 0;
+  pb_add_sme->setEnabled( !isSmeEmpty );
 }
 
 void US_ExperGuiRotor::init_grevs( void )

--- a/programs/us_experiment/us_experiment_gui_optima.h
+++ b/programs/us_experiment/us_experiment_gui_optima.h
@@ -321,6 +321,9 @@ class US_ExperGuiRotor : public US_WidgetsDialog
       void init_grevs( void );
       void init_gapprs( void );
       void init_gsmes( void );
+  
+      void setEnabledDisabledAddToORASME( void );
+    
       void addOpertoList( void );
       void removeOperfromList( void );
       void addRevtoList( void );


### PR DESCRIPTION
In a non-typical situation (such as newlims creation with no instrument operators, GMP reviwers and.or approvers not yest set), the operator, approver, reviewer and SME lists may be empty - disable "Add to List" buttons...