### PR TITLE
GMP, Prot_devel, utils/xpn_data : remove unused function, ensure xpn host is configured…

### DIFF
--- a/programs/us_com_project/us_com_project_gui.cpp
+++ b/programs/us_com_project/us_com_project_gui.cpp
@@ -792,112 +792,6 @@ void US_ComProjectMain::close_initDialogue( void )
 }
 
 
-//Slot to delete Postgres Optima ExperimentDefinition record
-void US_ComProjectMain::delete_psql_record( int ExpId )
-{
-  QString schname( "AUC_schema" );
-  
-  QString tabname_expdef( "ExperimentDefinition" );
-  QString tabname_fuge  ( "CentrifugeRunProfile" );
-  QString tabname_abs   ( "AbsorbanceScanParameters" );
-  
-  QString qrytab_expdef  = "\"" + schname + "\".\"" + tabname_expdef + "\"";
-  QString qrytab_fuge    = "\"" + schname + "\".\"" + tabname_fuge + "\"";
-  QString qrytab_abs     = "\"" + schname + "\".\"" + tabname_abs + "\"";
-  
-  
-  QString dbhost      = "demeler5.uleth.ca";
-  int     dbport      = 5552;
-  QString dbname      = "AUC_DATA_DB";
-  QString dbuser      = "";
-  QString dbpasw      = "";
-
-  QSqlDatabase dbxpn;
-  
-  dbxpn           = QSqlDatabase::addDatabase( "QPSQL", "" );
-  dbxpn.setDatabaseName( "XpnData" );
-  dbxpn.setHostName    ( dbhost );
-  dbxpn.setPort        ( dbport );
-  dbxpn.setDatabaseName( dbname  );
-  dbxpn.setUserName    ( dbuser  );
-  dbxpn.setPassword    ( dbpasw );
-
-  qDebug() << "Opening Postgres Connection!!!";
-  
-  if (  dbxpn.open() )
-    {
-      qDebug() << "Connected !!!";
-      
-      QSqlQuery query_expdef(dbxpn);
-      QSqlQuery query_fuge(dbxpn);
-      QSqlQuery query_abs_scan(dbxpn);
-     
-      /*
-      // AbsorbanceScanParameters
-      QString ScanId = "5996";
-      if(! query_abs_scan.prepare(QString("DELETE FROM %1 WHERE \"ScanId\" = %2").arg(qrytab_abs).arg(ScanId) ) )
-	qDebug() << query_abs_scan.lastError().text();
-
-      if (query_abs_scan.exec())
-	{
-	  qDebug() << "AbsorbanceScanParameters record # :" << ScanId  << "deleted !";
-	}
-      else
-	{
-	  QString errmsg   = "Delete record error: " + query_abs_scan.lastError().text();
-	  QMessageBox::critical( this,
-				 tr( "*ERROR* in Deleting Absorbance Record" ),
-				 tr( "An error occurred in the attempt to delete"
-				     " AbsorbanceScanParameters from AUC DB\n  %1 table\n  %2 ." ).arg( qrytab_abs ).arg( errmsg ) );
-	  return;
-	}
-      
-      // Cell Parameters
-      
-      
-      // FugeProfile
-      int FugeId = 308;
-      if(! query_fuge.prepare(QString("DELETE FROM %1 WHERE \"FugeRunProfileId\" = %2").arg(qrytab_fuge).arg(FugeId) ) )
-	qDebug() << query_fuge.lastError().text();
-
-      if (query_fuge.exec())
-	{
-	  qDebug() << "FugeProfile record # :" << FugeId  << "deleted !";
-	}
-      else
-	{
-	  QString errmsg   = "Delete record error: " + query_fuge.lastError().text();;
-	  QMessageBox::critical( this,
-				 tr( "*ERROR* in Deleting Fuge Profile" ),
-				 tr( "An error occurred in the attempt to delete"
-				     " FugeProfile from AUC DB\n  %1 table\n  %2 ." ).arg( qrytab_fuge ).arg( errmsg ) );
-	  return;
-	}
-
-      */
-
-      // ExperimentalDefinition
-      if(! query_expdef.prepare(QString("DELETE FROM %1 WHERE \"ExperimentId\" = %2").arg(qrytab_expdef).arg(ExpId) ) )
-	qDebug() << query_expdef.lastError().text();
-      
-      if (query_expdef.exec())
-	{
-	  qDebug() << "ExperimentDefinition record # :" << ExpId  << "deleted !";
-	}
-      else
-	{
-	  QString errmsg   = "Delete record error: " + query_expdef.lastError().text();;
-	  QMessageBox::critical( this,
-				 tr( "*ERROR* in Deleting Experimental Method" ),
-				 tr( "An error occurred in the attempt to delete"
-				     " exp. method from AUC DB\n  %1 table\n  %2 ." ).arg( qrytab_expdef ).arg( errmsg ) );
-	  return;
-	}
-				
-    }
-}
-
-
 // Slot to define new exp. (from initial dialog)
 void US_ComProjectMain::define_new_experiment( QStringList & occupied_instruments )
 {
@@ -1519,11 +1413,7 @@ void US_InitDialogueGui::initRecords( void )               // <-- 1st entry poin
   autoflow_records = get_autoflow_records();
   
   qDebug() << "Autoflow record #: " << autoflow_records;
-  
-  // //Temporary: delete ExperimentDefinition record ( ExpId = 306, 301 )
-  // int ExpId = 285;
-  // delete_psql_record( ExpId );
-  
+
   if ( autoflow_records < 1 )
     return;
   

--- a/programs/us_com_project/us_com_project_gui.h
+++ b/programs/us_com_project/us_com_project_gui.h
@@ -508,8 +508,6 @@ private slots:
   void to_autoflow_records( void );
 
   void define_new_experiment( QStringList & );
-
-  void delete_psql_record( int );
   
   void liveupdate_stopped( void );
 

--- a/programs/us_protocol_dev/us_protocol_dev_gui.cpp
+++ b/programs/us_protocol_dev/us_protocol_dev_gui.cpp
@@ -781,11 +781,7 @@ void US_InitDialogueGui::initRecords( void )               // <-- 1st entry poin
   autoflow_records = get_autoflow_records();
   
   qDebug() << "Autoflow record #: " << autoflow_records;
-  
-  // //Temporary: delete ExperimentDefinition record ( ExpId = 306, 301 )
-  // int ExpId = 285;
-  // delete_psql_record( ExpId );
-  
+    
   if ( autoflow_records < 1 )
     return;
   

--- a/utils/us_xpn_data.cpp
+++ b/utils/us_xpn_data.cpp
@@ -12,7 +12,8 @@ US_XpnData::US_XpnData( ) {
    clear();                // Clear internal vectors
 
    dbg_level    = US_Settings::us_debug();
-   dbhost       = QString( "bcf.uthscsa.edu" );
+   //dbhost       = QString( "bcf.uthscsa.edu" );
+   dbhost       = QString("");
    dbport       = 5432;
    dbname       = QString( "AUC_DATA_DB" );
    dbuser       = QString( "aucuser" );
@@ -37,7 +38,18 @@ bool US_XpnData::connect_data( const QString xpnhost, const int xpnport,
    const QString adbname, const QString adbuser, const QString adbpasw )
 {
    bool status   = true;
-   dbhost        = ( xpnhost.isEmpty() ) ? dbhost : xpnhost;
+
+   QString resolvedHost = xpnhost.isEmpty() ? dbhost : xpnhost;
+   if ( resolvedHost.isEmpty() )
+     {
+       qDebug() << "connect_data: ERROR - no database host specified";
+       emit status_text( "ERROR: No Optima host configured. Check instrument settings." );
+       return false;
+     }
+   
+   dbhost = resolvedHost;
+   
+   //dbhost        = ( xpnhost.isEmpty() ) ? dbhost : xpnhost;
    dbport        = ( xpnport <= 0 )      ? 5432   : xpnport;
    dbname        = ( adbname.isEmpty() ) ? dbname : adbname;
    dbuser        = ( adbuser.isEmpty() ) ? dbuser : adbuser;


### PR DESCRIPTION
1. Removed unused function (delete_psql_record) in us_com_project_gui.cpp/.h calling hard-coded "demeler5.xxx" hostname
2. In utils/us_xpn_data.cpp, set dbhost to be empty (instead of QString(  "bcf.uthscsa.edu" ); )
 This is beneficial for precluding a fake fallback (to "bfc.xx.edu") if Optima's hostname is not passed...
 connection stops right away, and user informed... 