### PR TITLE
GMP: dataDisk -- disable all upcoming tabs in 1. EXP settings when dataDisk selected to prevent user-filled protocol creation

### DIFF
--- a/programs/us_com_project/us_com_project_gui.cpp
+++ b/programs/us_com_project/us_com_project_gui.cpp
@@ -1389,7 +1389,7 @@ void US_InitDialogueGui::checkCertificates( void )
       return;
     }
 
-  // //TEST
+  //TEST
   // isDataDiskOnly = true;
   // emit pass_allow_dataDisk_only();
   //  End of checkig for conneciton to Optima sys_data server ///////////////////////////////////////////////

--- a/programs/us_com_project/us_com_project_gui.cpp
+++ b/programs/us_com_project/us_com_project_gui.cpp
@@ -1389,9 +1389,9 @@ void US_InitDialogueGui::checkCertificates( void )
       return;
     }
 
-  //TEST
-  //isDataDiskOnly = true;
-  //emit pass_allow_dataDisk_only();
+  // //TEST
+  // isDataDiskOnly = true;
+  // emit pass_allow_dataDisk_only();
   //  End of checkig for conneciton to Optima sys_data server ///////////////////////////////////////////////
 }
 

--- a/programs/us_experiment/us_exp_utils.cpp
+++ b/programs/us_experiment/us_exp_utils.cpp
@@ -285,6 +285,28 @@ void US_ExperimentMain::disable_tabs_buttons( void )
 
 }
 
+//Slot to DISABLE tabs after  2. Lab/Rotor and the Next buttons when dataDisk clicked/unclicked
+void US_ExperimentMain::disableEnable_tabs_for_dataDisk( bool disabled )
+{
+  qDebug() << "dataDisk checked ? " << disabled << ", tabs action...";
+  pb_next   ->setEnabled( !disabled );
+  
+  for (int i=2; i<tabWidget->count(); i++)
+    {
+      tabWidget ->setTabEnabled( i, !disabled );
+      if ( disabled )
+	tabWidget ->tabBar()->setTabTextColor( i, Qt::darkGray);
+      else
+	{
+	  QPalette pal = tabWidget ->tabBar()->palette();
+	  tabWidget ->tabBar()->setTabTextColor( i, pal.color(QPalette::WindowText) ); // Qt::black
+	}
+    }
+
+  qApp->processEvents();
+
+}
+
 //Slot to ENABLE tabs and Next/Prev buttons
 void US_ExperimentMain::enable_tabs_buttons( void )
 {
@@ -638,6 +660,7 @@ DbgLv(1) << "mainw->automode" << mainw->automode;
      }
    //////////////////
    mainw->enable_disable_prev_next_btns();
+
 }
 
 
@@ -1166,6 +1189,9 @@ DbgLv(1) << "EGRo: inP: calib_entr" << cal_entr;
    qDebug() << "Rotor::initPanel(), rpRotor->importData_absorbance_t, rpRotor->importData_absorbance_pa -- "
 	    << rpRotor->importData_absorbance_t <<  rpRotor->importData_absorbance_pa;
 
+   /////
+   mainw->enable_disable_prev_next_btns();
+   
 }
 
 void US_ExperGuiRotor::setEnabledDisabledAddToORASME( void )

--- a/programs/us_experiment/us_exp_utils.cpp
+++ b/programs/us_experiment/us_exp_utils.cpp
@@ -288,7 +288,6 @@ void US_ExperimentMain::disable_tabs_buttons( void )
 //Slot to DISABLE tabs after  2. Lab/Rotor and the Next buttons when dataDisk clicked/unclicked
 void US_ExperimentMain::disableEnable_tabs_for_dataDisk( bool disabled )
 {
-  qDebug() << "dataDisk checked ? " << disabled << ", tabs action...";
   pb_next   ->setEnabled( !disabled );
   
   for (int i=2; i<tabWidget->count(); i++)

--- a/programs/us_experiment/us_exp_utils.cpp
+++ b/programs/us_experiment/us_exp_utils.cpp
@@ -309,6 +309,11 @@ void US_ExperimentMain::disableEnable_tabs_for_dataDisk( bool disabled )
 //Slot to ENABLE tabs and Next/Prev buttons
 void US_ExperimentMain::enable_tabs_buttons( void )
 {
+  if ( currProto.rpRotor.importData &&
+       currProto.rpRotor.importDataDisk.isEmpty() &&
+       !us_prot_dev_mode)
+    return;
+  
   DbgLv(1) << "ENABLING!!!";
   pb_next   ->setEnabled(true);
   pb_prev   ->setEnabled(true);

--- a/programs/us_experiment/us_experiment_gui_optima.cpp
+++ b/programs/us_experiment/us_experiment_gui_optima.cpp
@@ -137,6 +137,9 @@ US_ExperimentMain::US_ExperimentMain() : US_Widgets()
    connect( epanGeneral, SIGNAL( go_back_to_run_manager( void )),
 	    this,      SLOT( switch_to_run_manager( void ) ));
 
+   connect( epanRotor, SIGNAL( disableEnable_tabs_dataDisk( bool )),
+            this,        SLOT(  disableEnable_tabs_for_dataDisk( bool ) ));
+
    //int min_width = tabWidget->tabBar()->width();
 
    //setMinimumSize( QSize( min_width, 450 ) );
@@ -576,7 +579,23 @@ void US_ExperimentMain::enable_disable_prev_next_btns( void )
   int lastTabIndex = totalTabs - 1;
   int currTabIndex = tabWidget->currentIndex();
   if ( currTabIndex == 0 )
-    pb_prev->setEnabled(false);
+    {
+      pb_prev->setEnabled(false);
+
+      //if dataDisk checked but NO data uploaded
+      if ( currProto.rpRotor.importData &&
+	   currProto.rpRotor.importDataDisk.isEmpty() &&
+	   !us_prot_dev_mode )
+	{
+	  pb_next->setEnabled(true);
+	}
+    }
+  if ( currTabIndex == 1 &&
+       currProto.rpRotor.importData &&
+       currProto.rpRotor.importDataDisk.isEmpty() &&
+       !us_prot_dev_mode )
+    pb_next->setEnabled(false);
+    
   if ( currTabIndex == lastTabIndex )
     pb_next->setEnabled(false);
 }
@@ -1700,6 +1719,9 @@ void US_ExperGuiRotor::switch_to_dataDisk_public()
 
   connect( ck_disksource, SIGNAL( toggled     ( bool ) ),
 	   this,           SLOT  ( importDiskChecked( bool ) ) );
+
+  //and disable tabs
+  emit disableEnable_tabs_dataDisk( true );
 }
 
 void US_ExperGuiRotor::get_chann_ranges_public( QString d_type, QMap< QString, QStringList>& f_data )
@@ -1797,7 +1819,8 @@ void US_ExperGuiRotor::importDiskChecked( bool checked )
       
       if (msgBox.clickedButton() == Accept_r)
 	{
-	  
+	  emit disableEnable_tabs_dataDisk( checked );
+	  return;
 	}
       else if (msgBox.clickedButton() == Cancel_r)
 	{
@@ -2173,6 +2196,9 @@ void US_ExperGuiRotor::importDisk( void )
 
   //set tabs readonly
   mainw->set_tabs_buttons_readonly_dataDisk( true );
+
+  //and enable tabs
+  emit disableEnable_tabs_dataDisk( false );
 }
 
 //

--- a/programs/us_experiment/us_experiment_gui_optima.h
+++ b/programs/us_experiment/us_experiment_gui_optima.h
@@ -332,6 +332,9 @@ class US_ExperGuiRotor : public US_WidgetsDialog
       void removeApprfromList( void );
       void addSmetoList( void );
       void removeSmefromList( void );
+
+   signals:
+      void disableEnable_tabs_dataDisk( bool );
   
 };
 
@@ -1191,6 +1194,7 @@ class US_ExperimentMain : public US_Widgets
       void enable_tabs_buttons( void);  // Slot to enable Tabs and Buttons after run_name is entered
       void set_tabs_buttons_readonly( void );
       void switch_to_run_manager( void );
+      void disableEnable_tabs_for_dataDisk( bool );				
 
 					
    public slots:


### PR DESCRIPTION
1. disable all upcoming tabs in 1. EXP settings when dataDisk selected; 
2. unlock only when valid .auc data-from-disk uploaded & downstream protocol parameters are generated; 
3. corrected behavior for Next/Previous lower buttons: disable Next when at 2. Lab/Rotor tab, enable when back to 1. General; disable when back to 2. Lab/Rorot ...

Tested for normal condition - when Optima connections are valid;
Emulated condition for no Optima instrument(s) available (dataDisk forced)