### PR TITLE
Update workflow configuration for commit SHA bump

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,6 +18,6 @@ permissions:
 
 jobs:
   create-release-pr:
-    uses: ehb54/uslims_version_workflows/.github/workflows/create-bump-pr.yml@d5b5a1e0274f6029177e2989ffa7a0f0e801521b
+    uses: ehb54/uslims_version_workflows/.github/workflows/create-bump-pr.yml@aacc200d0c68de5d0840c15567b484aac9a8018e
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
This pull request updates the version of the reusable workflow used in the `create-release-pr` job in `.github/workflows/bump-version.yml`. The update points to a newer commit of the external workflow.
