### PR TITLE
Fix macx build: guard -lqwtplot3d self-link and add -lus_utils to libus_gui

### DIFF
--- a/gui/libus_gui.pro
+++ b/gui/libus_gui.pro
@@ -6,6 +6,7 @@ QT            += printsupport
 }
 
 unix:   TARGET = us_gui
+macx:   LIBS  += -L../lib -lus_utils
 
 win32 {
         DEFINES += QWT_DLL US_MAKE_GUI_DLL

--- a/local.pri.template
+++ b/local.pri.template
@@ -86,7 +86,8 @@ macx {
   INCLUDEPATH += ../../Frameworks/QtSvg.framework/Headers
   INCLUDEPATH += ../../Frameworks/QtXml.framework/Headers
   LIBS        += -L/System/Library/Frameworks/OpenGL.framework/Libraries
-  LIBS	      += -lssl -lcrypto -lqwtplot3d
+  LIBS	      += -lssl -lcrypto
+  !equals(TARGET, qwtplot3d): LIBS += -lqwtplot3d
   LIBS	      += -framework QtOpenGL
   MYSQLPATH   = /usr/local/mysql
   MYSQLDIR    = $$MYSQLPATH/lib


### PR DESCRIPTION
## Summary

- **`local.pri.template` (macx):** `-lqwtplot3d` was on the same `LIBS` line as `-lssl -lcrypto`, which gets pulled into `qwtplot3d`'s own build via `library.pri` → `local.pri`. This caused `ld: library not found for -lqwtplot3d` on a clean build. Fix: split it onto a `!equals(TARGET, qwtplot3d)` guarded line so the library doesn't try to link against itself before it exists.
- **`gui/libus_gui.pro` (macx):** The Nov 2025 commit (5c92b75) moved `us_csv_loader`, `us_convert_gui`, `us_extinction_gui`, and related files into `libus_gui`, which reference symbols from `libus_utils`. The win32 block already had `-lus_utils`, but the macx block was missing it, causing undefined symbol errors at link time. Fix: add `macx: LIBS += -L../lib -lus_utils`.

## Test plan

- [ ] Clean macx build: `cd ultrascan3-main && . qt5env && qmake && make` completes with no errors
- [ ] `qwtplot3d` builds without `-lqwtplot3d` in its link line
- [ ] `libus_gui` links successfully against `libus_utils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)