### PR TITLE
Install sphinx requirements before building manual in redhat/ubuntu containers

### DIFF
--- a/admin/release/buildpkg.pl
+++ b/admin/release/buildpkg.pl
@@ -13,9 +13,7 @@
 
 my %supported =
     (
-     "ubuntu:18.04"  => "python"
-     ,"ubuntu:20.04" => "python"
-     ,"ubuntu:22.04" => "python3"
+     "ubuntu:22.04" => "python3"
      ,"ubuntu:24.04" => "python3"
      ,"redhat:8.10"   => "python3"
     );

--- a/admin/release/redhat/Dockerfile
+++ b/admin/release/redhat/Dockerfile
@@ -119,13 +119,19 @@ RUN dnf install -y graphviz
 ## upgrade doxygen as the file is often not current in repo
 RUN cd $ULTRASCAN && doxygen -u
 
+## the manual is built with sphinx, which needs a newer python3 than the platform default
+RUN dnf module enable -y python39 && dnf install -y python39 python39-pip
+RUN mkdir -p /tmp/python_bin && ln -sf /usr/bin/python3.9 /tmp/python_bin/python3
+RUN cd $ULTRASCAN/doc/manual/source && python3.9 -m pip install -r requirements.txt
+
 # make ultrascan
 ## faster qmake, make first
 RUN cd $ULTRASCAN && export PATH=$QTDIR/bin:$PATH && qmake && make -j$parallel_compile
 RUN cd $ULTRASCAN && export PATH=$QTDIR/bin:$PATH && ./makeall.sh -j$parallel_compile
 
 ## old versions of makeall.sh fail to build manual as it is doing in parallel, make sure we build the manual
-RUN cd $ULTRASCAN/doc/manual && export PATH=$QTDIR/bin:$PATH && make -j1
+## /tmp/python_bin is prepended so the Makefile's "python3 -m sphinx" resolves to python3.9
+RUN cd $ULTRASCAN/doc/manual && export PATH=/tmp/python_bin:$QTDIR/bin:$PATH && make -j1
 
 # make sure manual exists
 RUN cd $ULTRASCAN && ls -l bin/manual*

--- a/admin/release/ubuntu/Dockerfile
+++ b/admin/release/ubuntu/Dockerfile
@@ -2,7 +2,7 @@
 
 ### exposed ARGs override defaults with --build-arg <varname>=<value>
 
-ARG image=ubuntu:18.04
+ARG image=ubuntu:22.04
 ## ARGs are scoped FROM
 FROM $image
 
@@ -149,6 +149,10 @@ RUN cpan Template
 RUN apt-get install -y graphviz
 ## upgrade doxygen as the file is often not current in repo
 RUN cd $ULTRASCAN && doxygen -u
+
+## the manual is built with sphinx
+RUN apt-get install -y python3-pip
+RUN cd $ULTRASCAN/doc/manual/source && PIP_BREAK_SYSTEM_PACKAGES=1 pip3 install -r requirements.txt
 
 # make ultrascan
 ## faster qmake, make first


### PR DESCRIPTION
## Summary
- Install Sphinx (via requirements.txt) before the manual make step in admin/release/redhat/Dockerfile and admin/release/ubuntu/Dockerfile, fixing "No module named sphinx" build failures.
- RedHat: enable the python39 AppStream module stream (Rocky 8 default python3 is 3.6, too old for sphinx>=7) and symlink it onto PATH for the manual build only.
- Ubuntu: install python3-pip and pip3 install -r requirements.txt; bump default image ARG to ubuntu:22.04.
- Drop ubuntu:18.04/ubuntu:20.04 from buildpkg.pl's supported list since their system python3 is also too old for sphinx.

## Test plan
- [ ] Build redhat image: cd admin/release && perl buildpkg.pl <cores> redhat:8.10
- [ ] Build ubuntu image: cd admin/release && perl buildpkg.pl <cores> ubuntu:22.04
- [ ] Confirm manual builds (bin/manual* present) without "No module named sphinx"
