### PR TITLE
Fix qwt download URL: versaweb mirror replaced with downloads.sourceforge.net

### DIFF
--- a/admin/release/redhat/Dockerfile
+++ b/admin/release/redhat/Dockerfile
@@ -89,7 +89,7 @@ RUN cd qt-everywhere-src-$qt_version && nohup make install -j1 2>&1 > makeinstal
 # RUN ls -l /qt-$qt_version/bin /qt-$qt_version/lib
 
 # install qwt
-RUN wget https://versaweb.dl.sourceforge.net/project/qwt/qwt/$qwt_version/qwt-$qwt_version.tar.bz2 && tar jxf qwt-$qwt_version.tar.bz2 && cd qwt-$qwt_version && /qt-$qt_version/bin/qmake && make -j$parallel_compile
+RUN wget https://downloads.sourceforge.net/project/qwt/qwt/$qwt_version/qwt-$qwt_version.tar.bz2 && tar jxf qwt-$qwt_version.tar.bz2 && cd qwt-$qwt_version && /qt-$qt_version/bin/qmake && make -j$parallel_compile
 
 # get source
 ## invalidate docker cache

--- a/admin/release/ubuntu/Dockerfile
+++ b/admin/release/ubuntu/Dockerfile
@@ -120,7 +120,7 @@ RUN cd qt-everywhere-src-$qt_version && nohup make install -j1 2>&1 > makeinstal
 RUN rm -r qt-everywhere-src-$qt_version
 
 # install qwt
-RUN wget https://versaweb.dl.sourceforge.net/project/qwt/qwt/$qwt_version/qwt-$qwt_version.tar.bz2 && tar jxf qwt-$qwt_version.tar.bz2 && cd qwt-$qwt_version && /qt-$qt_version/bin/qmake && make -j$parallel_compile
+RUN wget https://downloads.sourceforge.net/project/qwt/qwt/$qwt_version/qwt-$qwt_version.tar.bz2 && tar jxf qwt-$qwt_version.tar.bz2 && cd qwt-$qwt_version && /qt-$qt_version/bin/qmake && make -j$parallel_compile
 
 # get source
 ## invalidate docker cache


### PR DESCRIPTION
## Summary
- The versaweb sourceforge mirror used to fetch qwt is no longer reliable; switch to the generic downloads.sourceforge.net redirector in both redhat and ubuntu release Dockerfiles.
