### PR TITLE
Fix linux.pl package name generation for new version/revision header format

### DIFF
--- a/admin/release/linux.pl
+++ b/admin/release/linux.pl
@@ -23,13 +23,20 @@ die "$qwt is not a directory\n" if !-d $qwt;
 
 $rfile = "$us/programs/us/us_revision.h";
 die "$rfile does not exist\n" if !-e $rfile;
-$cmd = "grep REVISION $rfile | awk -F\\\" '{ print \$2 }'";
-# print "$cmd\n";
-$rev = `$cmd`;
-chomp $rev;
-print "revision is $rev\n";
+$vfile = "$us/utils/us_defines.h";
+die "$vfile does not exist\n" if !-e $vfile;
 
-$dd = "us3-$sn-64-4.0.$rev";
+$cmd = "grep BUILDNUM $rfile | awk -F\\\" '{ print \$2 }'";
+$buildnum = `$cmd`;
+chomp $buildnum;
+
+$cmd = "grep US_Version $vfile | awk -F\\\" '{ print \$2 }'";
+$version = `$cmd`;
+chomp $version;
+
+print "version is $version build $buildnum\n";
+
+$dd = "us3-$sn-64-$version-build-$buildnum";
 print "$dd\n";
 
 die "$dd exists, please remove it first


### PR DESCRIPTION
## Summary
- `us_revision.h` changed format: it no longer has a single `REVISION` field, but separate `BUILDNUM`/`GIT_REVISION`/`REVISION_DATE`/`LOCAL_CHANGES` fields.
- `admin/release/linux.pl`'s `grep REVISION` matched both `GIT_REVISION` and `REVISION_DATE`, producing a multi-line value embedded into the package directory name, which broke subsequent shell commands built from it (e.g. `mkdir $dd`). This affected both the redhat and ubuntu release Dockerfiles, since both call this shared script.
- Build the package name from `US_Version` (`utils/us_defines.h`) and `BUILDNUM` instead, e.g. `us3-redhat-8.10-64-4.1.0-dev-build-9149`.

Fixes ehb54/ultrascan-tickets#910

## Test plan
- [ ] Build redhat container, confirm `linux.pl` produces a valid single-line package name and `us3-*.tar.xz` is created
- [ ] Build ubuntu container, confirm the same
