### PR TITLE
makeall.sh: robust sphinx/python3 detection for DOMAN on RHEL8 variants

### DIFF
--- a/makeall.sh
+++ b/makeall.sh
@@ -67,7 +67,12 @@ _doc_python_version_ok() {
 # RHEL8 variants ship different combinations of python3.11/python3.12 (and a
 # too-old default python3).
 find_doc_python() {
-  if command -v sphinx-build >/dev/null 2>&1 && sphinx-build --version >/dev/null 2>&1; then
+  # doc/manual/Makefile invokes the interpreter as plain "python3", not
+  # "sphinx-build" (SPHINXBUILD ?= python3 -m sphinx). Checking
+  # sphinx-build here would be checking the wrong command: an unrelated
+  # sphinx-build script tied to some other (possibly too-old) interpreter
+  # can be on PATH and "work" while "python3 -m sphinx" still fails.
+  if _doc_python_version_ok python3 && python3 -c 'import sphinx' >/dev/null 2>&1; then
     return 0
   fi
 

--- a/makeall.sh
+++ b/makeall.sh
@@ -83,7 +83,12 @@ find_doc_python() {
       return 0
     fi
 
-    ${py} -m ensurepip --upgrade >/dev/null 2>&1
+    # Plain ensurepip (no --upgrade) just installs the wheel bundled in
+    # the Python install itself -- fully offline. --upgrade would make
+    # pip then try to upgrade itself from PyPI, which fails outright on
+    # network-restricted hosts and isn't needed just to get a working
+    # pip module for the requirements.txt install below.
+    ${py} -m ensurepip >/dev/null 2>&1
     if ${py} -m pip install --user -q -r doc/manual/source/requirements.txt >/dev/null 2>&1 \
       || ${py} -m pip install --user --break-system-packages -q -r doc/manual/source/requirements.txt >/dev/null 2>&1
     then

--- a/makeall.sh
+++ b/makeall.sh
@@ -51,6 +51,17 @@ DODOX=1
 DOC_PYTHON=""
 DOC_PYTHON_BINDIR=""
 
+# doc/manual/source/conf.py uses Python >=3.9 syntax (PEP 585 builtin
+# generics, e.g. "list[str]"), so any candidate interpreter older than
+# that must be rejected outright -- even if some (possibly stale) Sphinx
+# package happens to already be importable for it. A too-old default
+# python3 (e.g. RHEL's 3.6) with a leftover manual "pip install --user"
+# from before this version check existed is exactly this trap: "import
+# sphinx" succeeds, but the build then fails on conf.py.
+_doc_python_version_ok() {
+  "$1" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)' >/dev/null 2>&1
+}
+
 # Find a Python interpreter that can run Sphinx, installing it for that
 # interpreter if needed. Avoids hardcoding a single python3.X version since
 # RHEL8 variants ship different combinations of python3.11/python3.12 (and a
@@ -63,7 +74,7 @@ find_doc_python() {
   local pyver py
   for pyver in python3.12 python3.11 python3.10 python3.9 python3; do
     py=`command -v ${pyver} 2>/dev/null`
-    if [ -z "$py" ]; then
+    if [ -z "$py" ] || ! _doc_python_version_ok "$py"; then
       continue
     fi
 

--- a/makeall.sh
+++ b/makeall.sh
@@ -48,8 +48,47 @@ fi
 
 DOMAN=1
 DODOX=1
+DOC_PYTHON=""
+DOC_PYTHON_BINDIR=""
 
-if [ -z "`which sphinx-build`" ]; then
+# Find a Python interpreter that can run Sphinx, installing it for that
+# interpreter if needed. Avoids hardcoding a single python3.X version since
+# RHEL8 variants ship different combinations of python3.11/python3.12 (and a
+# too-old default python3).
+find_doc_python() {
+  if command -v sphinx-build >/dev/null 2>&1 && sphinx-build --version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local pyver py
+  for pyver in python3.12 python3.11 python3.10 python3.9 python3; do
+    py=`command -v ${pyver} 2>/dev/null`
+    if [ -z "$py" ]; then
+      continue
+    fi
+
+    if ${py} -c 'import sphinx' >/dev/null 2>&1; then
+      DOC_PYTHON=${py}
+      return 0
+    fi
+
+    ${py} -m ensurepip --upgrade >/dev/null 2>&1
+    if ${py} -m pip install --user -q -r doc/manual/source/requirements.txt >/dev/null 2>&1 \
+      || ${py} -m pip install --user --break-system-packages -q -r doc/manual/source/requirements.txt >/dev/null 2>&1
+    then
+      if ${py} -c 'import sphinx' >/dev/null 2>&1; then
+        DOC_PYTHON=${py}
+        return 0
+      fi
+    fi
+  done
+
+  return 1
+}
+
+if ! find_doc_python; then
+  echo "WARNING: no usable Python/Sphinx found - documentation will not be built."
+  echo "  Install manually: python3 -m pip install -r doc/manual/source/requirements.txt"
   DOMAN=0
 fi
 if [ -z "`which doxygen`" ]; then
@@ -99,8 +138,20 @@ if [ $DOMAN -ne 0 ]; then
   sdir=`pwd`
   echo "Making in $d"   >> $DIR/build.log
   ## n.b. the make failes with parallel builds, require -j1
-  make -j1 2>&1  >> $DIR/build.log
+  if [ -n "$DOC_PYTHON" ]; then
+    # doc/manual/Makefile invokes the interpreter as plain "python3"; if the
+    # interpreter we found is named e.g. python3.11, shim a "python3" on
+    # PATH for this build only, so we don't affect anything else.
+    DOC_PYTHON_BINDIR=`mktemp -d`
+    ln -s "$DOC_PYTHON" "$DOC_PYTHON_BINDIR/python3"
+    PATH="$DOC_PYTHON_BINDIR:$PATH" make -j1 2>&1  >> $DIR/build.log
+  else
+    make -j1 2>&1  >> $DIR/build.log
+  fi
   stat=$?
+  if [ -n "$DOC_PYTHON_BINDIR" ]; then
+    rm -rf "$DOC_PYTHON_BINDIR"
+  fi
   if [ $stat -gt 0 ]; then
      echo "  ***ERROR*** building $d"
      NBERR=`expr ${NBERR} + 1`


### PR DESCRIPTION
## Summary

- `makeall.sh`'s `DOMAN` detection only checked `which sphinx-build`, which is unreliable on RHEL8 variants where the default `python3` is too old (3.6) and the usable `python3.11`/`python3.12` interpreters rarely have a `sphinx-build` shim on `PATH`.
- Added a `find_doc_python()` search (newest-first: `python3.12`, `python3.11`, `python3.10`, `python3.9`, `python3`) that prefers an already-working `sphinx-build`, otherwise checks if `sphinx` is importable for each candidate interpreter, self-installing via `ensurepip` + `pip install -r doc/manual/source/requirements.txt` (with a `--break-system-packages` fallback) if needed.
- Since `doc/manual/Makefile` invokes the interpreter as plain `python3`, the doc-build step now shims a scoped `python3` symlink on `PATH` only around that `make -j1` call when the chosen interpreter has a different name, without affecting the rest of the build.
- Falls back to `DOMAN=0` with a warning, same as before, if no usable Sphinx install can be found.

Fixes ehb54/ultrascan-tickets#925

## Test plan

- [ ] `bash -n makeall.sh` passes
- [ ] Ran `find_doc_python()` standalone on macOS with no `sphinx-build` on `PATH`; correctly found a `python3` with Sphinx importable
- [ ] Run `./makeall.sh` on a RHEL8 host with only `python3.11` installed and no `sphinx-build` on `PATH`; confirm docs build and `DOMAN=1`
- [ ] Run on a host with a working `sphinx-build` already on `PATH`; confirm fast path is used and docs still build
