### PR TITLE
Include LICENSE.txt in Linux release packages

### DIFF
--- a/admin/release/linux.pl
+++ b/admin/release/linux.pl
@@ -213,6 +213,9 @@ print OUT $ftxt;
 close OUT;
 docmd( "chmod a+rx $f" );
 
+## license file
+docmd( "cp $us/LICENSE.txt ." );
+
 # make tar
 
 chdir $basedir;


### PR DESCRIPTION
## Summary
- The Linux tar.xz packaging script (`admin/release/linux.pl`) never copied `LICENSE.txt` into the package, unlike the Windows packaging script (`copypkg-win.sh`) which already does this.
- Adds the same `LICENSE.txt` copy step so Linux packages ship a license file too, consistent with Windows and macOS packages.

## Test plan
- [x] `perl -c admin/release/linux.pl` syntax check passes
- [x] Run a release container build (`admin/release/buildpkg.pl <cores> <image>`) and confirm the resulting `us3-<image>-64-*.tar.xz` contains `LICENSE.txt` at its root

Fixes ehb54/ultrascan-tickets#868