### PR TITLE
GMP-dataDisk: 1. EXP: 5. Solutions -- exclude (unspecified) item in all solution cahnnels for uploaded form disk data...

### DIFF
--- a/programs/us_experiment/us_exp_utils.cpp
+++ b/programs/us_experiment/us_exp_utils.cpp
@@ -2641,6 +2641,18 @@ DbgLv(1) << "EGSo:inP: mxrow" << mxrow << "labls count" << cc_labls.count();
 	      this,         SLOT  ( changeSolu         ( int ) ) );
       
    }
+
+ //If dataDisk, disallow (unspecified)
+   if( rpRotor->importData && !rpRotor->importDataDisk.isEmpty() )
+     {
+       for ( int ii = 0; ii < cc_solus.size(); ii++ )
+	 {
+	   QString substring = "(unspecified)";
+	   int index;
+	   while ((index = cc_solus[ ii ]->findText(substring, Qt::MatchContains)) != -1)
+	     cc_solus[ ii ]->removeItem(index);
+	 }
+     }
 }
 
 // Save panel controls when about to leave the panel


### PR DESCRIPTION
When in GMP program data is uploaded form disk, ensure in 5. Solutions tab, all items "(unspecified)" are excluded from comboxes as user may select them which will lead to disruption of the protocol population corresponding to the uploaded data.

(Before we addressed  a similar issue for 4. Cell, by removing "empty" entries...)