### PR TITLE
fix: restrict Sphinx dirty-check to source files (issue #936)

### DIFF
--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -48,11 +48,15 @@ def generate_version_metadata(source_dir: str | os.PathLike[str]) -> dict[str, s
     git_revision = _run_git(["rev-parse", "--short=7", "HEAD"], source_dir) or "unknown"
     git_branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], source_dir) or "unknown"
 
-    # Tracked changes only: ignore untracked files
+    # Tracked changes to source files only: ignore untracked files and
+    # non-source changes (docs, scripts, etc.) so that building docs from a
+    # tree with only doc/script modifications does not mark the software dirty.
+    # Matches the filter used by programs/us/revision.sh.
+    _SOURCE_PATHSPECS = ["--", "*.h", "*.cpp", "*.ui", "*.qrc"]
     dirty = False
     try:
         worktree_rc = subprocess.run(
-            ["git", "diff", "--quiet", "--exit-code"],
+            ["git", "diff", "--quiet", "--exit-code"] + _SOURCE_PATHSPECS,
             cwd=str(source_dir),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
@@ -60,7 +64,7 @@ def generate_version_metadata(source_dir: str | os.PathLike[str]) -> dict[str, s
         ).returncode
 
         index_rc = subprocess.run(
-            ["git", "diff", "--quiet", "--cached", "--exit-code"],
+            ["git", "diff", "--quiet", "--cached", "--exit-code"] + _SOURCE_PATHSPECS,
             cwd=str(source_dir),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary

- `doc/manual/source/conf.py` was running `git diff` with no path filter, so any modified tracked file (doc, script, `.cmake`, etc.) caused the Qt Help version string to show `Δ` (dirty flag)
- `programs/us/revision.sh` (splash screen) already restricts the same check to `*.h *.cpp *.ui *.qrc` — the splash screen therefore showed no dirty flag
- On the macOS 4.1.0 release build, a non-source tracked file was modified, causing `conf.py` to detect dirty state while `revision.sh` did not — inconsistent behaviour reported in #936
- Fix: add the identical `-- *.h *.cpp *.ui *.qrc` pathspec to both `git diff` calls in `conf.py`

## Test plan

- [ ] Build Sphinx docs (`make qthelp`) on a tree with only doc/script changes — verify no `Δ` in the Qt Help namespace
- [ ] Build Sphinx docs on a tree with a modified `.cpp` or `.h` — verify `Δ` still appears
- [ ] Confirm splash screen and Help version info agree on dirty/clean state

Closes #936

🤖 Generated with [Claude Code](https://claude.com/claude-code)