### PR TITLE
fix: change qthelp namespace from org.sphinx to com.aucsolutions

### DIFF
--- a/doc/manual/source/conf.py
+++ b/doc/manual/source/conf.py
@@ -251,7 +251,7 @@ htmlhelp_basename = 'UltraScanIIIdoc'
 
 # Namespace used by
 qthelp_basename = 'manual'
-qthelp_namespace = f'org.sphinx.{qthelp_basename}.{version}-{meta["BUILD_NUMBER"]}-{meta["GIT_REVISION"]}{meta["GIT_DIRTY_FLAG"]}'
+qthelp_namespace = f'com.aucsolutions.{qthelp_basename}.{version}-{meta["BUILD_NUMBER"]}-{meta["GIT_REVISION"]}{meta["GIT_DIRTY_FLAG"]}'
 # -- Options for LaTeX output ------------------------------------------------
 # Use XeLaTeX for proper Unicode support
 latex_engine = "xelatex"


### PR DESCRIPTION
## Summary

- Changes `qthelp_namespace` in `doc/manual/source/conf.py` to use `com.aucsolutions` instead of `org.sphinx`
- QtHelp URLs will now resolve as `qthelp://com.aucsolutions.manual.<version>/...` instead of `qthelp://org.sphinx.manual.<version>/...`

Closes ehb54/ultrascan-tickets#939

## Test plan

- [ ] Build the QtHelp docs and confirm the namespace in the generated `.qhp` file reflects `com.aucsolutions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)