### PR TITLE
fix: update browser settings handling for MacOS and Windows

### DIFF
--- a/gui/us_help.cpp
+++ b/gui/us_help.cpp
@@ -87,8 +87,25 @@ void US_Help::show_html_file( const QString& location )
 // Open a web page or file in the user's configured browser
 void US_Help::openBrowser( const QString& location )
 {
+   QString program = US_Settings::browser();
+
+   if ( program.isEmpty() )
+   {
+      // No browser explicitly configured -- use the OS default.
+      if ( !QDesktopServices::openUrl( QUrl( location ) ) )
+      {
+         QMessageBox::warning( 0,
+            tr( "Ultrascan III Error" ),
+            tr( "Cannot open the system default browser ...\n"
+                "Please insure you have a default browser configured "
+                "for your operating system or set one explicitly in "
+                "UltraScan Configuration.\n\n"
+                "  URL: %1" ).arg( location ) );
+      }
+      return;
+   }
+
    QProcess*   proc    = new QProcess( this );
-   QString     program = US_Settings::browser();
    QStringList args;
 
 #ifndef Q_OS_MAC

--- a/utils/us_settings.cpp
+++ b/utils/us_settings.cpp
@@ -6,7 +6,18 @@
 QString US_Settings::browser( void )
 {
   QSettings settings( US3, "UltraScan" );
-  return settings.value( "browser",  "/usr/bin/firefox" ).toString();
+  QString   value = settings.value( "browser", "" ).toString();
+
+#if defined( Q_OS_MAC ) || defined( Q_OS_WIN )
+  // Self-heal a stale "/usr/bin/firefox" default that earlier versions
+  // could persist on save even when the user never set a browser. That
+  // path is a real, possibly intentional setting on Linux, so leave it
+  // alone there.
+  if ( value == "/usr/bin/firefox" )
+    value = "";
+#endif
+
+  return value;
 }
 
 void US_Settings::set_browser( const QString& browser )

--- a/utils/us_settings.cpp
+++ b/utils/us_settings.cpp
@@ -509,7 +509,7 @@ bool US_Settings::get_DA_status( const QString& da_type )
 {
   QSettings settings( US3, "UltraScan" );
 
-  int status; 
+  int status = 0;
   if ( da_type == "COM" )
     status = settings.value( "daComOpened", QString() ).toInt();
 


### PR DESCRIPTION
## Summary
- Help → UltraScan Home / Upgrade UltraScan silently did nothing on macOS (and likely Windows), because `US_Settings::browser()` defaulted to the hardcoded Linux path `/usr/bin/firefox`. On macOS, `open -a /usr/bin/firefox <url>` fails asynchronously after `QProcess::waitForStarted()` already reports success, so the app's own error dialog never fired.
- `US_Settings::browser()` now defaults to `""` instead of `/usr/bin/firefox`, and self-heals any stale persisted `/usr/bin/firefox` value on macOS/Windows only (left untouched on Linux, where it's a plausible real setting).
- `US_Help::openBrowser()` now uses `QDesktopServices::openUrl()` (the OS default browser) when no browser is explicitly configured, with a warning dialog on failure. An explicitly configured browser still launches via the existing platform-specific path, unchanged.

## Test plan
- [x] Built and manually tested locally (Help → UltraScan Home / Upgrade UltraScan now open in the system default browser on macOS)
- [x] Verified Linux explicit-browser-setting code path is unchanged
- [x] Tested on Windows 11 Pro (Build 26200) — Help → UltraScan Home / Upgrade UltraScan open in the system default browser

Closes ehb54/ultrascan-tickets#941